### PR TITLE
[Feature] 카카오 소셜 로그인 및 회원가입 기능 구현 #9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out/
 # 환경변수 파일
 .env*
 backend/env
+
+# .gitignore yml 로컬 프로필 설정
+application-local.yml

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,44 +1,54 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.4'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.4'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.team6'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1' // swagger
-	implementation 'mysql:mysql-connector-java:8.0.33' // mysql
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0")
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1' // swagger
+    implementation 'mysql:mysql-connector-java:8.0.33' // mysql
+    implementation 'org.springframework.boot:spring-boot-starter-webflux' // WebClient:  비동기식 HTTP 요청을 처리하기 위해 사용
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    implementation 'org.springframework:spring-context'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2', 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.lettuce:lettuce-core' //// 기본 Redis 클라이언트
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.0")
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/backend/src/main/java/com/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/backend/domain/member/controller/MemberController.java
@@ -85,7 +85,7 @@ public class MemberController {
         return ResponseEntity.ok().body(GenericResponse.of(responseDto));
     }
 
-    // 닉네임 검색
+    // 닉네임으로 회원 검색
     @GetMapping("/search")
     public ResponseEntity<GenericResponse<List<MemberInfoDto>>> searchMembersByNickname(@RequestParam String nickname) {
         List<MemberInfoDto> members = memberService.searchByNickname(nickname);

--- a/backend/src/main/java/com/backend/domain/member/dto/MemberRegisterRequestDto.java
+++ b/backend/src/main/java/com/backend/domain/member/dto/MemberRegisterRequestDto.java
@@ -1,7 +1,7 @@
 package com.backend.domain.member.dto;
 
 import org.hibernate.validator.constraints.Length;
-
+import com.backend.global.auth.kakao.dto.KakaoUserInfoResponseDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -33,8 +33,26 @@ public record MemberRegisterRequestDto(
         // @Size(min = 1, max = 5, message = "1~5개의 이미지가 필요합니다.")
         // List<ImageRegisterRequest> images,
 
-        // 위도, 경도 추가
+
+        // 위도, 경도
         Double latitude,
         Double longitude
 
-) {}
+) {
+        /**
+         * 카카오 사용자 정보로부터 회원가입 DTO 생성
+         */
+        public static MemberRegisterRequestDto fromKakao(KakaoUserInfoResponseDto dto) {
+                return new MemberRegisterRequestDto(
+                        dto.id(),
+                        dto.kakaoAccount().email(),
+                        dto.properties().nickname(),
+                        "UNKNOWN",     // 기본 성별
+                        0,             // 기본 나이
+                        0,             // 기본 키
+//                        new ArrayList<>(), // 빈 프로필 이미지 리스트
+                        null,          // 위도
+                        null           // 경도
+                );
+        }
+}

--- a/backend/src/main/java/com/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/backend/domain/member/entity/Member.java
@@ -107,8 +107,11 @@ public class Member extends BaseEntity {
         this.longitude = longitude;
     }
 
-    public void updateKakaoToken(String accessToken, String refreshToken) {
+    public void updateAccessToken(String accessToken) {
         this.kakaoAccessToken = accessToken;
+
+    }
+    public void updateRefreshToken(String refreshToken) {
         this.kakaoRefreshToken = refreshToken;
     }
 

--- a/backend/src/main/java/com/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/backend/domain/member/repository/MemberRepository.java
@@ -30,4 +30,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // 닉네임 검색 (회원 리스트)
     // DTO 변환은 서비스에서 map(MemberInfoDto::from) 사용
     List<Member> findByNicknameContaining(String nickname);
+
+    Optional<Member> findByKakaoRefreshToken(String kakaoRefreshToken);
+
 }

--- a/backend/src/main/java/com/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/backend/domain/member/service/MemberService.java
@@ -152,4 +152,11 @@ public class MemberService {
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
+    @Transactional(readOnly = true)
+    public Member findByKakaoRefreshToken(String refreshToken) {
+
+        return memberRepository.findByKakaoRefreshToken(refreshToken).orElseThrow(() ->
+                new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
 }

--- a/backend/src/main/java/com/backend/global/auth/exception/JwtException.java
+++ b/backend/src/main/java/com/backend/global/auth/exception/JwtException.java
@@ -1,0 +1,15 @@
+package com.backend.global.auth.exception;
+
+import com.backend.global.exception.GlobalErrorCode;
+import com.backend.global.exception.GlobalException;
+
+/**
+ * JWT 관련 예외 클래스
+ * GlobalException을 상속받아 GlobalErrorCode 기반으로 예외 처리한다.
+ */
+
+public class JwtException extends GlobalException {
+    public JwtException(GlobalErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend/src/main/java/com/backend/global/auth/jwt/JwtFilter.java
+++ b/backend/src/main/java/com/backend/global/auth/jwt/JwtFilter.java
@@ -1,0 +1,48 @@
+package com.backend.global.auth.jwt;
+
+import com.backend.global.auth.kakao.service.CookieService;
+import com.backend.global.auth.kakao.util.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import java.io.IOException;
+
+/**
+ * JWT 인증 필터
+ * 매 요청마다 실행되며, 쿠키에서 Access Token을 추출해 유효성 검증 후
+ * Spring Security의 SecurityContext에 인증 정보를 저장하는 역할을 한다.
+ */
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final CookieService cookieService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        // 1. 쿠키에서 AccessToken 추출 (CookieService 활용)
+        String token = cookieService.getAccessTokenFromCookie(request);
+
+        // 2. 토큰이 존재하고 유효하면
+        if (token != null && jwtUtil.validateToken(token)) {
+            // 2-1. JWT로부터 인증(Authentication) 객체 생성
+            Authentication authentication = jwtUtil.getAuthentication(token);
+
+            // 2-2. SecurityContext에 인증 정보 저장
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        // 3. 다음 필터로 이동
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/backend/global/auth/kakao/controller/KakaoAuthController.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/controller/KakaoAuthController.java
@@ -1,0 +1,127 @@
+package com.backend.global.auth.kakao.controller;
+
+import com.backend.global.auth.exception.JwtException;
+import com.backend.global.auth.kakao.dto.LoginResponseDto;
+import com.backend.global.auth.kakao.service.CookieService;
+import com.backend.global.auth.kakao.service.KakaoAuthService;
+import com.backend.global.auth.kakao.service.RedisRefreshTokenService;
+import com.backend.global.auth.kakao.util.TokenProvider;
+import com.backend.global.auth.model.CustomUserDetails;
+import com.backend.global.exception.GlobalErrorCode;
+import com.backend.global.response.GenericResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 카카오 소셜 로그인 인증을 처리하는 컨트롤러 클래스
+ * - 로그인 URL 요청, 로그인 및 회원가입 처리, 토큰 재발급, 로그아웃, 토큰 리프레시 등을 담당
+ */
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth/kakao")
+public class KakaoAuthController {
+
+    private final KakaoAuthService kakaoAuthService;
+    private final CookieService cookieService;
+    private final RedisRefreshTokenService redisRefreshTokenService;
+    private final TokenProvider tokenProvider;
+
+    @Value("${client.base-url}")
+    private String clientBaseUrl;
+
+    // 카카오 인가 URL을 프론트에 전달
+    @GetMapping("/login-url")
+    public ResponseEntity<String> getKakaoLoginUrl() {
+        return ResponseEntity.ok(kakaoAuthService.getKakaoAuthorizationUrl());
+    }
+
+
+    /**
+     * 로그인 API (인가코드로 로그인 및 회원가입 처리)
+     */
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseDto> kakaoLogin(@RequestParam String code, HttpServletResponse response) {
+        LoginResponseDto loginResult = kakaoAuthService.processLogin(code, response);
+        return ResponseEntity.ok(loginResult);
+    }
+
+    /**
+     * 프론트 리다이렉트용 콜백 핸들러
+     * 로그인 후 콜백 요청 처리 (액세스/리프레시 토큰을 쿠키에 설정)
+     */
+    @GetMapping("/callback")
+    public ResponseEntity<GenericResponse<LoginResponseDto>> loginCallback(@RequestParam String code, HttpServletResponse response) {
+        LoginResponseDto login = kakaoAuthService.processLogin(code, response);
+
+        cookieService.addAccessTokenToCookie(login.accessToken(), response);
+        cookieService.addRefreshTokenToCookie(login.refreshToken(), response);
+
+        return ResponseEntity.ok(GenericResponse.of(login, "로그인 성공"));
+    }
+
+    /**
+     * 리프레시 토큰을 통해 새로운 액세스 토큰 재발급
+     */
+    @PostMapping("/reissue")
+    public ResponseEntity<LoginResponseDto> reissue(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = cookieService.getRefreshTokenFromCookie(request);
+
+        Long memberId = tokenProvider.parseToken(refreshToken).get("id", Long.class);
+
+        if (!tokenProvider.validateToken(refreshToken)) {
+            throw new JwtException(GlobalErrorCode.INVALID_TOKEN);
+        }
+
+        if (redisRefreshTokenService.isValid(memberId, refreshToken)) {
+            throw new JwtException(GlobalErrorCode.TOKEN_EXPIRED);
+        }
+
+        LoginResponseDto newToken = kakaoAuthService.reissueTokens(refreshToken);
+
+        cookieService.addRefreshTokenToCookie(newToken.refreshToken(), response);
+        return ResponseEntity.ok(newToken);
+    }
+
+    /**
+     * 로그아웃 처리 (리프레시 토큰 삭제, 쿠키 제거)
+     */
+    @PostMapping("/logout")
+    // AuthenticationPrincipal CustomUserDetails를 통해 인증된 사용자 정보 가져옴
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                       HttpServletResponse response) {
+        Long memberId = userDetails.getMemberId(); // 인증 정보에서 ID 추출
+        redisRefreshTokenService.deleteRefreshToken(memberId);
+        cookieService.clearTokensFromCookie(response);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 쿠키에서 리프레시 토큰을 기반으로 새로운 액세스 토큰 재발급
+     */
+    @GetMapping("/refresh")
+    public ResponseEntity<LoginResponseDto> refreshToken(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                         HttpServletRequest request) {
+        String refreshToken = cookieService.getRefreshTokenFromCookie(request);
+        Long memberId = userDetails.getMemberId(); // 인증 정보에서 ID 추출
+
+        if (!tokenProvider.validateToken(refreshToken)) {
+            throw new JwtException(GlobalErrorCode.INVALID_TOKEN);
+        }
+
+        if (!redisRefreshTokenService.isValid(memberId, refreshToken)) {
+            throw new JwtException(GlobalErrorCode.TOKEN_EXPIRED);
+        }
+
+        String newAccessToken = tokenProvider.createAccessToken(memberId);
+        return ResponseEntity.ok(LoginResponseDto.of(newAccessToken, memberId, refreshToken));
+    }
+    
+}

--- a/backend/src/main/java/com/backend/global/auth/kakao/dto/KakaoTokenResponseDto.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/dto/KakaoTokenResponseDto.java
@@ -1,0 +1,16 @@
+package com.backend.global.auth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 카카오 토큰 응답 DTO
+ * - 카카오 서버에서 받은 토큰 정보를 매핑하는 역할
+ */
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoTokenResponseDto(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("expires_in") Long expiresIn
+) {}

--- a/backend/src/main/java/com/backend/global/auth/kakao/dto/KakaoUserInfoResponseDto.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/dto/KakaoUserInfoResponseDto.java
@@ -1,0 +1,19 @@
+package com.backend.global.auth.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 카카오 사용자 정보 API 응답을 매핑하는 DTO
+ * 닉네임, 프로필 이미지, 이메일 등을 포함
+ */
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoUserInfoResponseDto(
+        @JsonProperty("id") Long id,
+        @JsonProperty("properties") Properties properties,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+    public record Properties(String nickname, String profile_image) {}
+    public record KakaoAccount(String email) {}
+}

--- a/backend/src/main/java/com/backend/global/auth/kakao/dto/LoginResponseDto.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/dto/LoginResponseDto.java
@@ -1,0 +1,20 @@
+package com.backend.global.auth.kakao.dto;
+
+import lombok.Builder;
+
+/**
+ * 로그인 성공 시 클라이언트에 전달되는 응답 DTO
+ * accessToken, userId, refreshToken을 포함
+ */
+
+@Builder
+public record LoginResponseDto(String accessToken, String memberId, String refreshToken) {
+
+    /**
+     * 응답 객체 생성 메서드
+     */
+    public static LoginResponseDto of(String accessToken, Long memberId, String refreshToken) {
+        return new LoginResponseDto(accessToken, String.valueOf(memberId), refreshToken);
+    }
+}
+

--- a/backend/src/main/java/com/backend/global/auth/kakao/service/CookieService.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/service/CookieService.java
@@ -1,0 +1,59 @@
+package com.backend.global.auth.kakao.service;
+
+import com.backend.global.auth.kakao.util.CookieUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 리프레시 토큰과 액세스 토큰을 쿠키에 저장하고, 추출하고, 삭제하는 서비스
+ * 내부적으로 CookieUtil을 사용함
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CookieService {
+
+    private final CookieUtil cookieUtil;
+
+    private static final String ACCESS_TOKEN = "accessToken";
+    private static final String REFRESH_TOKEN = "refreshToken";
+
+    /**
+     * 요청에서 accessToken 쿠키 값을 추출
+     */
+    public String getAccessTokenFromCookie(HttpServletRequest request) {
+        return cookieUtil.getCookieValue(request, ACCESS_TOKEN);
+    }
+
+    /**
+     * 요청에서 refreshToken 쿠키 값을 추출
+     */
+    public String getRefreshTokenFromCookie(HttpServletRequest request) {
+        return cookieUtil.getCookieValue(request, REFRESH_TOKEN);
+    }
+
+    /**
+     * accessToken 쿠키 저장 (6시간 유지)
+     */
+    public void addAccessTokenToCookie(String token, HttpServletResponse response) {
+        cookieUtil.addCookie(ACCESS_TOKEN, token, 60 * 60 * 6, response); // 6시간
+    }
+
+    /**
+     * refreshToken 쿠키 저장 (60일 유지)
+     */
+    public void addRefreshTokenToCookie(String token, HttpServletResponse response) {
+        cookieUtil.addCookie(REFRESH_TOKEN, token, 60 * 60 * 24 * 60, response); // 60일
+    }
+
+    /**
+     * accessToken, refreshToken 쿠키 삭제
+     */
+    public void clearTokensFromCookie(HttpServletResponse response) {
+        cookieUtil.deleteCookie(ACCESS_TOKEN, response);
+        cookieUtil.deleteCookie(REFRESH_TOKEN, response);
+    }
+}

--- a/backend/src/main/java/com/backend/global/auth/kakao/service/KakaoAuthService.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/service/KakaoAuthService.java
@@ -1,0 +1,149 @@
+package com.backend.global.auth.kakao.service;
+
+import com.backend.domain.member.dto.MemberRegisterRequestDto;
+import com.backend.domain.member.entity.Member;
+import com.backend.domain.member.repository.MemberRepository;
+import com.backend.domain.member.service.MemberService;
+import com.backend.global.auth.kakao.dto.KakaoTokenResponseDto;
+import com.backend.global.auth.kakao.dto.KakaoUserInfoResponseDto;
+import com.backend.global.auth.kakao.dto.LoginResponseDto;
+import com.backend.global.auth.kakao.util.JwtUtil;
+import com.backend.global.auth.kakao.util.KakaoAuthUtil;
+import com.backend.global.auth.kakao.util.TokenProvider;
+import com.backend.global.exception.GlobalErrorCode;
+import com.backend.global.exception.GlobalException;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * 카카오 인가 코드를 받아 회원 정보를 조회하고 JWT 토큰을 발급하는 인증 서비스
+ * 회원이 존재하지 않으면 자동으로 회원가입 진행
+ * 발급한 리프레시 토큰은 Redis와 쿠키에 저장
+ */
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoAuthService {
+    // 카카오 API 호출 관련 유틸
+    private final KakaoAuthUtil kakaoAuthUtil;
+    private final WebClient webClient;
+
+    // JWT 관련 유틸
+    private final TokenProvider tokenProvider;
+    private final JwtUtil jwtUtil;
+
+    // 회원 등록/조회 서비스
+    private final MemberService memberService;
+    private final MemberRepository memberRepository;
+
+    // Redis에 리프레시 토큰 저장
+    private final RedisRefreshTokenService redisRefreshTokenService;
+
+    // 쿠키 관련 서비스 및 유틸
+    private final CookieService cookieService;
+
+    /**
+     * 카카오 로그인 인가 요청 URL 반환
+     */
+    public String getKakaoAuthorizationUrl() {
+        return kakaoAuthUtil.getKakaoAuthorizationUrl();
+    }
+
+    /**
+     * 인가 코드를 통해 카카오로부터 토큰 발급받기
+     */
+    public KakaoTokenResponseDto getTokenFromKakao(String code) {
+        return webClient.post()
+                .uri(kakaoAuthUtil.getKakaoLoginTokenUrl(code))
+                .retrieve()
+                .bodyToMono(KakaoTokenResponseDto.class)
+                .block();
+    }
+
+    /**
+     * 카카오 accessToken을 사용해 사용자 정보 조회
+     */
+    public KakaoUserInfoResponseDto getUserInfo(String accessToken) {
+        return webClient.get()
+                .uri(kakaoAuthUtil.getUserInfoUrl())
+                .headers(h -> {
+                    h.setBearerAuth(accessToken);
+                    h.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                })
+                .retrieve()
+                .bodyToMono(KakaoUserInfoResponseDto.class)
+                .block();
+    }
+
+    /**
+     * 카카오 인가 코드를 통해 로그인 또는 회원가입 처리 후 JWT 토큰 발급
+     */
+    // 회원 조회 및 회원가입
+    public LoginResponseDto processLogin(String code, HttpServletResponse response) {
+        // 1. 인가 코드로 accessToken, refreshToken 발급받기
+        KakaoTokenResponseDto kakaoTokenDto = getTokenFromKakao(code);
+        String kakaoAccessToken = kakaoTokenDto.accessToken();
+        String kakaoRefreshToken = kakaoTokenDto.refreshToken();
+
+        // 2. 카카오 accessToken으로 사용자 정보 요청
+        KakaoUserInfoResponseDto kakaoUserInfo = getUserInfo(kakaoAccessToken);
+        Long kakaoId = kakaoUserInfo.id();
+
+        // 3. 해당 kakaoId가 등록된 사용자인지 확인 (회원인지 아닌지 확인)
+        Member member = memberRepository.findByKakaoId(kakaoId).orElse(null);
+
+        if (member == null) {
+            // 3-1. 신규 사용자라면 registerMember 호출
+            MemberRegisterRequestDto registerDto = MemberRegisterRequestDto.fromKakao(kakaoUserInfo);
+            memberService.registerMember(registerDto);
+
+            // 등록 후 다시 조회
+            member = memberRepository.findByKakaoId(kakaoId)
+                    .orElseThrow(() -> new GlobalException(GlobalErrorCode.MEMBER_REGISTRATION_FAILED));
+        } else {
+            // 3-2. 기존 회원이면 카카오 토큰 업데이트
+            member.updateAccessToken(kakaoAccessToken);
+            member.updateRefreshToken(kakaoRefreshToken);
+        }
+
+        // 4. JWT access, refresh 토큰 생성
+        String accessToken = tokenProvider.createAccessToken(member.getId());
+        String refreshToken = tokenProvider.createRefreshToken(member.getId());
+
+        // 5. Redis에 리프레시 토큰 저장 (중복 로그인 방지)
+        long ttl = jwtUtil.getRefreshTokenExpirationTime();
+        redisRefreshTokenService.saveRefreshToken(member.getId(), refreshToken, ttl);
+
+        // 6. 리프레시 토큰을 쿠키에 저장
+        cookieService.addRefreshTokenToCookie(refreshToken, response);
+
+        // 7. 응답 DTO 반환
+        return LoginResponseDto.of(accessToken, member.getId(), refreshToken);
+    }
+
+    /**
+     * 카카오 리프레시 토큰을 통해 accessToken 재발급
+     */
+    public LoginResponseDto reissueTokens(String refreshToken) {
+        Member member = memberService.findByKakaoRefreshToken(refreshToken);
+
+        KakaoTokenResponseDto newToken = webClient.post()
+                .uri(kakaoAuthUtil.getKakaoTokenReissueUrl(refreshToken))
+                .retrieve()
+                .bodyToMono(KakaoTokenResponseDto.class)
+                .block();
+
+        member.updateAccessToken(newToken.accessToken());
+        if (newToken.refreshToken() != null) {
+            member.updateRefreshToken(newToken.refreshToken());
+        }
+
+        return LoginResponseDto.of(newToken.accessToken(), member.getId(), newToken.refreshToken());
+
+    }
+}

--- a/backend/src/main/java/com/backend/global/auth/kakao/service/RedisRefreshTokenService.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/service/RedisRefreshTokenService.java
@@ -1,0 +1,58 @@
+package com.backend.global.auth.kakao.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+/**
+ * Redis를 활용하여 리프레시 토큰을 저장, 검증, 삭제하는 서비스
+ * - 저장 시 만료시간을 함께 설정함
+ * - 저장 키는 "RT:{memberId}" 형식으로 구성됨
+ */
+
+@Service
+@RequiredArgsConstructor
+public class RedisRefreshTokenService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    /**
+     * 리프레시 토큰을 Redis에 저장
+     * @param memberId 사용자 ID
+     * @param token 저장할 리프레시 토큰
+     * @param expiration 토큰 만료시간 (밀리초)
+     */
+    public void saveRefreshToken(Long memberId, String token, long expiration) {
+        redisTemplate.opsForValue().set(getKey(memberId), token, Duration.ofMillis(expiration));
+    }
+
+    /**
+     * 저장된 리프레시 토큰이 유효한지 검증
+     * @param memberId 사용자 ID
+     * @param token 요청에서 받은 리프레시 토큰
+     * @return 토큰이 일치하면 true
+     */
+    public boolean isValid(Long memberId, String token) {
+        String storedToken = redisTemplate.opsForValue().get(getKey(memberId));
+        return storedToken != null && storedToken.equals(token);
+    }
+
+    /**
+     * Redis에서 리프레시 토큰 삭제
+     * @param memberId 사용자 ID
+     */
+    public void deleteRefreshToken(Long memberId) {
+        redisTemplate.delete(getKey(memberId));
+    }
+
+    /**
+     * Redis에 저장될 키 형식 생성
+     * @param memberId 사용자 ID
+     * @return "RT:{memberId}" 형식의 키
+     */
+    private String getKey(Long memberId) {
+        return "RT:" + memberId;
+    }
+}

--- a/backend/src/main/java/com/backend/global/auth/kakao/util/CookieUtil.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/util/CookieUtil.java
@@ -1,0 +1,64 @@
+package com.backend.global.auth.kakao.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+/**
+ * 쿠키 관련 기능을 제공하는 유틸리티 클래스
+ * - 요청에서 쿠키 값을 조회
+ * - 응답에 쿠키 추가
+ * - 쿠키 삭제
+ */
+
+@Component
+public class CookieUtil {
+
+    /**
+     * 요청에 포함된 쿠키 중에서 지정한 이름의 쿠키 값을 반환
+     * @param request 요청 객체
+     * @param name 찾을 쿠키 이름
+     * @return 쿠키 값 또는 null
+     */
+    public String getCookieValue(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return null;
+
+        for (Cookie cookie : request.getCookies()) {
+            if (name.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 쿠키를 생성하고 응답에 추가
+     * @param name 쿠키 이름
+     * @param value 쿠키 값
+     * @param maxAge 쿠키 만료 시간 (초 단위)
+     * @param response 응답 객체
+     */
+    public void addCookie(String name, String value, long maxAge, HttpServletResponse response) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge((int) maxAge);
+        response.addCookie(cookie);
+    }
+
+    /**
+     * 지정한 이름의 쿠키를 삭제 (유효시간 0으로 설정)
+     * @param name 삭제할 쿠키 이름
+     * @param response 응답 객체
+     */
+    public void deleteCookie(String name, HttpServletResponse response) {
+        Cookie cookie = new Cookie(name, null);
+        cookie.setMaxAge(0); // 즉시 만료
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+    }
+}

--- a/backend/src/main/java/com/backend/global/auth/kakao/util/JwtUtil.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/util/JwtUtil.java
@@ -1,0 +1,115 @@
+package com.backend.global.auth.kakao.util;
+
+import com.backend.global.auth.exception.JwtException;
+import com.backend.global.auth.model.CustomUserDetails;
+import com.backend.global.exception.GlobalErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * JWT를 통한 인증 정보를 처리하는 유틸리티 클래스
+ * - 토큰 파싱
+ * - 사용자 인증 정보 추출
+ * - JWT 관련 예외 처리 담당
+ */
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    @Value("${spring.security.jwt.secret}")
+    private String secretKey;
+
+    private Key key;
+
+    @Value("${spring.security.jwt.access-token.expiration}")
+    private long ACCESS_TOKEN_EXPIRATION_TIME; // 6시간 (단위: ms)
+
+    @Value("${spring.security.jwt.refresh-token.expiration}")
+    private long REFRESH_TOKEN_EXPIRATION_TIME; // 60일(약 2달) (단위: ms)
+
+    public Long getAccessTokenExpirationTime() {
+        return ACCESS_TOKEN_EXPIRATION_TIME;
+    }
+
+    public Long getRefreshTokenExpirationTime() {
+        return REFRESH_TOKEN_EXPIRATION_TIME;
+    }
+
+    // secretKey를 기반으로 Key key를 초기화
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+
+    public String createAccessToken(Long memberId, String email) {
+        return Jwts.builder()
+                .setSubject(email)
+                .claim("id", memberId)
+                .claim("email", email)
+                .claim("role", "ROLE_USER")
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION_TIME))
+                .signWith(key)
+                .compact();
+    }
+
+    public String createRefreshToken(Long memberId) {
+        return Jwts.builder()
+                .setSubject("RefreshToken")
+                .claim("id", memberId)
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION_TIME))
+                .signWith(key)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new JwtException(GlobalErrorCode.TOKEN_EXPIRED);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new JwtException(GlobalErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    public Claims parseToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseToken(token);
+
+        Long memberId = claims.get("id", Long.class);
+        String email = claims.get("email", String.class);
+        String role = claims.get("role", String.class);
+
+        CustomUserDetails userDetails = new CustomUserDetails(
+                memberId,
+                email,
+                List.of(new SimpleGrantedAuthority(role))
+        );
+
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+}

--- a/backend/src/main/java/com/backend/global/auth/kakao/util/KakaoAuthUtil.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/util/KakaoAuthUtil.java
@@ -1,0 +1,69 @@
+package com.backend.global.auth.kakao.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * 카카오 OAuth 관련 URL을 동적으로 생성하는 유틸 클래스
+ * - 인가 코드 요청 URL
+ * - 액세스 토큰 요청 URL
+ * - 사용자 정보 요청 URL
+ * - 리프레시 토큰 갱신 URL
+ */
+
+@Component
+public class KakaoAuthUtil {
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String CLIENT_ID;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String REDIRECT_URI;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.authorization-grant-type}")
+    private String GRANT_TYPE;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.authorization-uri}")
+    private String AUTH_URI;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    private String TOKEN_URI;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+    private String USER_INFO_URI;
+
+    // 사용자가 카카오 로그인 버튼 클릭 시 리디렉션될 인가 코드 요청 URL
+    public String getKakaoAuthorizationUrl() {
+        return UriComponentsBuilder.fromUriString(AUTH_URI)
+                .queryParam("response_type", "code")
+                .queryParam("client_id", CLIENT_ID)
+                .queryParam("redirect_uri", REDIRECT_URI)
+                .toUriString();
+    }
+
+    // 인가 코드로 카카오 액세스 토큰을 요청하는 URL
+    public String getKakaoLoginTokenUrl(String code) {
+        return UriComponentsBuilder.fromUriString(TOKEN_URI)
+                .queryParam("grant_type", GRANT_TYPE)
+                .queryParam("client_id", CLIENT_ID)
+                .queryParam("redirect_uri", REDIRECT_URI)
+                .queryParam("code", code)
+                .toUriString();
+    }
+
+    // 사용자 정보 요청 URL
+    public String getUserInfoUrl() {
+        return USER_INFO_URI;
+    }
+
+    // 카카오 리프레시 토큰으로 액세스 토큰 갱신 요청 URL
+    public String getKakaoTokenReissueUrl(String refreshToken) {
+        return UriComponentsBuilder.fromUriString(TOKEN_URI)
+                .queryParam("grant_type", "refresh_token")
+                .queryParam("client_id", CLIENT_ID)
+                .queryParam("refresh_token", refreshToken)
+                .toUriString();
+    }
+}
+

--- a/backend/src/main/java/com/backend/global/auth/kakao/util/TokenProvider.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/util/TokenProvider.java
@@ -1,0 +1,93 @@
+package com.backend.global.auth.kakao.util;
+
+import com.backend.global.exception.GlobalErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.time.Duration;
+import java.util.Date;
+
+
+/**
+ * JWT 토큰 유효성 검사 및 사용자 정보 추출을 담당하는 유틸 클래스
+ * JwtUtil과 CookieUtil을 내부적으로 활용함
+ */
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+
+    @Value("${spring.security.jwt.secret}")
+    private String secret;
+
+    private long accessTokenExpiration;
+
+    private long refreshTokenExpiration;
+
+    // JWT 서명을 위한 Key 생성
+    private Key getSigningKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    // 액세스 토큰 생성 (30분 TTL)
+    public String createAccessToken(Long memberId) {
+        return createToken(memberId, Duration.ofMinutes(30));
+    }
+
+    // 리프레시 토큰 생성 (14일 TTL)
+    public String createRefreshToken(Long memberId) {
+        return createToken(memberId, Duration.ofDays(14));
+    }
+
+    // JWT 생성 (공통 로직)
+    public String createToken(Long memberId, Duration ttl) {
+        Date now = new Date();
+        return Jwts.builder()
+                .claim("id", memberId) // member primary key
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ttl.toMillis()))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 토큰에서 사용자 ID 추출
+    public Long extractMemberId(String token) {
+        return ((Number) parseToken(token).get("id")).longValue();
+    }
+
+    // 토큰 유효성 검사 결과(만료 or 변조 여부 확인)를 TokenStatus enum으로 반환
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new com.backend.global.auth.exception.JwtException(GlobalErrorCode.TOKEN_EXPIRED);
+        } catch (io.jsonwebtoken.JwtException | IllegalArgumentException e) {
+            throw new com.backend.global.auth.exception.JwtException(GlobalErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    // JWT 파싱
+    public Claims parseToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+}

--- a/backend/src/main/java/com/backend/global/auth/model/CustomUserDetails.java
+++ b/backend/src/main/java/com/backend/global/auth/model/CustomUserDetails.java
@@ -1,0 +1,63 @@
+package com.backend.global.auth.model;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Spring Security의 Authentication 객체 내부에 저장될 사용자 정보 클래스
+ * 사용자 ID, 이메일, 권한 목록을 담고 있으며, 인증된 사용자 정보를 표현함
+ */
+
+public class CustomUserDetails implements UserDetails {
+    @Getter
+    private final Long memberId;
+    private final String email;
+    private final List<GrantedAuthority> authorities;
+
+    public CustomUserDetails(Long memberId, String email, List<GrantedAuthority> authorities) {
+        this.memberId = memberId;
+        this.email = email;
+        this.authorities = authorities;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    // 소셜 로그인에서는 사용하지 않음
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/backend/src/main/java/com/backend/global/config/CorsConfig.java
+++ b/backend/src/main/java/com/backend/global/config/CorsConfig.java
@@ -1,0 +1,4 @@
+package com.backend.global.config;
+
+public class CorsConfig {
+}

--- a/backend/src/main/java/com/backend/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/backend/global/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    // application.yml 파일에서 Redis 호스트 정보 주입
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    // application.yml 파일에서 Redis 포트 정보 주입
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    // Redis 접속을 위한 연결 팩토리 Bean 등록 (Lettuce 사용)
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    // RedisTemplate 등록 - Redis와 상호작용할 수 있는 템플릿 객체
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+}

--- a/backend/src/main/java/com/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/backend/global/config/SecurityConfig.java
@@ -1,0 +1,95 @@
+package com.backend.global.config;
+
+import com.backend.global.auth.jwt.JwtFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+
+/**
+ * SecurityConfig
+ * 시큐리티 관련 설정 클래스
+ */
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
+
+    // 인증 매니저를 빈으로 등록
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    // 핵심 보안 설정 (필터 체인 구성)
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/auth/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/webjars/**"
+                        ).permitAll().anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+
+
+
+//    @Bean
+//    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+//        http
+//                .csrf(AbstractHttpConfigurer::disable)
+//                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+//                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+//                .authorizeHttpRequests(auth -> auth
+//                        .requestMatchers("/api/auth/**").permitAll()
+//                        .anyRequest().authenticated()
+//                )
+//                .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+//
+//        return http.build();
+//    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOrigins(List.of("http://localhost:3000")); // 프론트 주소
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true); // 쿠키 전송 허용
+        config.setExposedHeaders(List.of("Authorization")); // 필요한 경우 expose
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }
+}
+

--- a/backend/src/main/java/com/backend/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/backend/global/config/SwaggerConfig.java
@@ -53,7 +53,7 @@ public class SwaggerConfig {
     public GroupedOpenApi authApi() {
         return GroupedOpenApi.builder()
                 .group("Auth")
-                .pathsToMatch("/auth/**")
+                .pathsToMatch("/api/auth/**")
                 .build();
     }
 

--- a/backend/src/main/java/com/backend/global/config/WebClientConfig.java
+++ b/backend/src/main/java/com/backend/global/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}

--- a/backend/src/main/java/com/backend/global/exception/GlobalErrorCode.java
+++ b/backend/src/main/java/com/backend/global/exception/GlobalErrorCode.java
@@ -13,8 +13,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum GlobalErrorCode {
 
-	INVALID_REQUEST(HttpStatus.BAD_REQUEST, 400, "잘못된 요청입니다."),
-	SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 오류가 발생했습니다."),
 
 	// 이미지 도메인 세부 에러
 	IMAGE_COUNT_INVALID(HttpStatus.BAD_REQUEST, 400, "이미지는 1장 이상 5장 이하로 등록해야 합니다."),
@@ -30,7 +28,20 @@ public enum GlobalErrorCode {
 
 	// 멤버 오류코드
 	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, 404, "해당 유저를 찾을 수 없습니다."),
-	DUPLICATE_MEMBER(HttpStatus.CONFLICT, 409, "이미 등록된 회원입니다.");
+	DUPLICATE_MEMBER(HttpStatus.CONFLICT, 409, "이미 등록된 회원입니다."),
+
+	// 정리 필요
+	SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 오류가 발생했습니다."),
+	INVALID_REQUEST(HttpStatus.BAD_REQUEST, 400, "잘못된 요청입니다."),
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 401-1, "유효하지 않은 토큰입니다."),
+	TOKEN_REISSUE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 401-2, "토큰 갱신에 실패했습니다."),
+	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, 402, "토큰이 만료되었습니다."),
+	UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, 403, "지원하지 않는 JWT 입니다."),
+	REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, 404, "리프레시 토큰이 존재하지 않습니다."),
+	MEMBER_REGISTRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500-1, "멤버를 찾을 수 없습니다.");
+
+
+
 
 
 	private final HttpStatus httpStatus;

--- a/backend/src/main/java/com/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/backend/global/exception/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package com.backend.global.exception;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.backend.domain.member.exception.MemberException;
+import com.backend.global.auth.exception.JwtException;
+import com.backend.global.response.GenericResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -10,11 +12,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
-import com.backend.domain.member.exception.MemberException;
-import com.backend.global.response.GenericResponse;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.ConstraintViolationException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * GlobalExceptionHandler
@@ -72,6 +71,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ex.getStatus())
                 .body(GenericResponse.fail(ex.getStatus(), ex.getMessage()));
+    }
+
+    /**
+     * JWT 예외 처리
+     */
+    @ExceptionHandler(JwtException.class)
+    public ResponseEntity<GenericResponse<?>> handleJwtException(JwtException ex) {
+        GlobalErrorCode errorCode = ex.getGlobalErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(GenericResponse.fail(errorCode.getHttpStatus().value(), errorCode.getMessage()));
     }
 
     /**

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,19 +1,15 @@
 spring:
-  config:
-    import: optional:file:.env[.properties]
-  datasource:
-    url: jdbc:mysql://localhost:3306/meeting_app?serverTimezone=Asia/Seoul
-    username: root
-    password: 3251
-    driver-class-name: com.mysql.cj.jdbc.Driver
-
+  profiles:
+    active: local
+  application:
+    name: backend
   jpa:
     hibernate:
-      ddl-auto: update
-    show-sql: true
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true
+<<<<<<< HEAD
     database-platform: org.hibernate.dialect.MySQL8Dialect
 server:
   port: 8080
@@ -24,3 +20,6 @@ cloud:
       bucket: devcouse4-team06-bucket
       region: ap-northeast-2
       url-prefix: https://devcouse4-team06-bucket.s3.ap-northeast-2.amazonaws.com/
+=======
+    show-sql: true
+>>>>>>> 18d8d1a (feat: 카카오 소셜 로그인 및 회원가입 기능 구현)

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -9,17 +9,5 @@ spring:
     properties:
       hibernate:
         format_sql: true
-<<<<<<< HEAD
-    database-platform: org.hibernate.dialect.MySQL8Dialect
-server:
-  port: 8080
-
-cloud:
-  aws:
-    s3:
-      bucket: devcouse4-team06-bucket
-      region: ap-northeast-2
-      url-prefix: https://devcouse4-team06-bucket.s3.ap-northeast-2.amazonaws.com/
-=======
     show-sql: true
->>>>>>> 18d8d1a (feat: 카카오 소셜 로그인 및 회원가입 기능 구현)
+


### PR DESCRIPTION
- 카카오 OAuth2 로그인 연동
- 신규 회원 자동 가입 처리
- JWT 기반 인증 토큰 발급 및 응답
- SecurityConfig에서 Swagger 경로 허용 및 JWT 필터 적용
- 관련 DTO 및 예외 처리 클래스 구현

<!-- 제목 : convention: 기능명#issue 번호
  ex) [FEAT] : pull request template #17-->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra


## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)


## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?


## 🔎 작업 내용

<!--resolves #{Issue번호} + Enter
ex) resolves #17
ex) close #17
이슈와 PR 연결을 위해 사용합니다!-->

- [x] 카카오 소셜 로그인 & 회원가입
카카오 OAuth 2.0 인증을 통해 사용자 정보를 받아와 자체 회원가입을 진행하거나 로그인 처리함
신규 유저일 경우 자동 회원가입, 기존 유저일 경우 로그인 처리
JWT 기반 Access Token, Refresh Token 발급 및 관리

- [x] JWT 인증 시스템
Access Token은 인증 처리에 사용
Refresh Token은 Redis에 저장되며, 만료된 Access Token 재발급 시 사용
인증 정보를 Spring Security의 SecurityContextHolder에 저장

- [x] 쿠키 기반 인증
Access Token, Refresh Token을 HttpOnly Secure 쿠키로 클라이언트에 전달
클라이언트 요청 시 쿠키를 통해 인증 수행

- [x] Security 설정 (SecurityConfig.java)

- [x] 기타 구현 요소
application-local.yml에 Kakao OAuth2 설정 및 JWT 설정 추가
로그인/회원가입 실패 시 GlobalExceptionHandler에서 에러 코드별 처리

특징 및 보안 고려
HttpOnly 쿠키: XSS로부터 토큰 보호
Secure 속성: HTTPS에서만 쿠키 전달
토큰 만료 시간: Access: 30분, Refresh: 14일
Refresh Token 관리: Redis에서만 저장, 재발급 시 검증
사용자 정보: 카카오 id, nickname, email, profile image 등



**보안 흐름 요약**
1. 사용자가 카카오 로그인 버튼 클릭 → 카카오 인증 서버에서 인가 코드 수신
2. 인가 코드를 바탕으로 KakaoAuthUtil에서 access token 발급 요청
3. 사용자 정보 API를 통해 사용자 이메일 등 추출
4. 해당 이메일로 신규 유저면 회원가입, 기존 유저면 로그인
5. TokenProvider에서 access/refresh 토큰 발급
6. access 토큰은 Authorization 헤더로, refresh 토큰은 CookieService를 통해 쿠키로 저장
7. 이후 요청에서는 access 토큰으로 인증, 필요시 refresh 토큰으로 재발급 (Redis 확인)



## 팀원 공유 내용
추후 리팩토링이 필요할 수도 있습니다!

## 📈이미지 첨부
