### PR TITLE
[Refactor] 카카오 로그인/회원가입 서비스 로직 리팩토링 #22

### DIFF
--- a/backend/src/main/java/com/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/backend/domain/member/entity/Member.java
@@ -1,29 +1,18 @@
 package com.backend.domain.member.entity;
 
-import java.util.List;
-
 import com.backend.domain.image.entity.Image;
 import com.backend.domain.member.dto.MemberRegisterRequestDto;
 import com.backend.global.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.util.List;
 
+@Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity
+@AllArgsConstructor
+@Builder
 public class Member extends BaseEntity {
 
     @Id
@@ -72,6 +61,19 @@ public class Member extends BaseEntity {
     // 회원 탈퇴(soft delete)
     @Column(nullable = false)
     private boolean isDeleted = false;
+
+    // 카카오에서 받아온 데이터를 저장하는 정적 팩토리 메서드
+    public static Member ofKakaoUser(Long kakaoId, String email, String nickname) {
+        return Member.builder()
+                .kakaoId(kakaoId)
+                .email(email)
+                .nickname(nickname)
+                .age(0)
+                .height(0)
+                .gender("UNKNOWN")
+                .chatAble(true)
+                .build();
+    }
 
     @Builder
     public Member(Long kakaoId, String email, String nickname,

--- a/backend/src/main/java/com/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/backend/domain/member/entity/Member.java
@@ -97,7 +97,7 @@ public class Member extends BaseEntity {
     }
 
     public void updateProfile(String nickname, Integer age, Integer height, String gender,
-        List<Image> images, Boolean chatAble,
+                              List<Image> images, Boolean chatAble,
                               Double latitude, Double longitude) {
         this.nickname = nickname;
         this.age = age;
@@ -113,6 +113,7 @@ public class Member extends BaseEntity {
         this.kakaoAccessToken = accessToken;
 
     }
+
     public void updateRefreshToken(String refreshToken) {
         this.kakaoRefreshToken = refreshToken;
     }

--- a/backend/src/main/java/com/backend/global/auth/kakao/controller/KakaoAuthController.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/controller/KakaoAuthController.java
@@ -1,5 +1,7 @@
 package com.backend.global.auth.kakao.controller;
 
+import com.backend.domain.member.entity.Member;
+import com.backend.domain.member.service.MemberService;
 import com.backend.global.auth.exception.JwtException;
 import com.backend.global.auth.kakao.dto.LoginResponseDto;
 import com.backend.global.auth.kakao.service.CookieService;
@@ -33,6 +35,7 @@ public class KakaoAuthController {
     private final CookieService cookieService;
     private final RedisRefreshTokenService redisRefreshTokenService;
     private final TokenProvider tokenProvider;
+    private final MemberService memberService;
 
     @Value("${client.base-url}")
     private String clientBaseUrl;
@@ -121,7 +124,11 @@ public class KakaoAuthController {
         }
 
         String newAccessToken = tokenProvider.createAccessToken(memberId);
-        return ResponseEntity.ok(LoginResponseDto.of(newAccessToken, memberId, refreshToken,true));
+
+        // 필요한 kakaoId 조회
+        Member member = memberService.getByKakaoId(memberId);
+        return ResponseEntity.ok(LoginResponseDto.of(newAccessToken, member.getKakaoId(), memberId
+                , refreshToken, true));
     }
-    
+
 }

--- a/backend/src/main/java/com/backend/global/auth/kakao/controller/KakaoAuthController.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/controller/KakaoAuthController.java
@@ -121,7 +121,7 @@ public class KakaoAuthController {
         }
 
         String newAccessToken = tokenProvider.createAccessToken(memberId);
-        return ResponseEntity.ok(LoginResponseDto.of(newAccessToken, memberId, refreshToken));
+        return ResponseEntity.ok(LoginResponseDto.of(newAccessToken, memberId, refreshToken,true));
     }
     
 }

--- a/backend/src/main/java/com/backend/global/auth/kakao/dto/LoginResponseDto.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/dto/LoginResponseDto.java
@@ -4,17 +4,32 @@ import lombok.Builder;
 
 /**
  * 로그인 성공 시 클라이언트에 전달되는 응답 DTO
- * accessToken, userId, refreshToken을 포함
+ * accessToken, refreshToken, memberId, isRegistered 포함
  */
-
 @Builder
-public record LoginResponseDto(String accessToken, String memberId, String refreshToken) {
+public record LoginResponseDto(
+        String accessToken,
+        String memberId,
+        String refreshToken,
+        boolean isRegistered
+) {
 
     /**
      * 응답 객체 생성 메서드
+     *
+     * @param accessToken   발급된 액세스 토큰
+     * @param memberId      회원 ID (String으로 변환)
+     * @param refreshToken  발급된 리프레시 토큰
+     * @param isRegistered  기존 회원 여부
+     * @return 응답 DTO
      */
-    public static LoginResponseDto of(String accessToken, Long memberId, String refreshToken) {
-        return new LoginResponseDto(accessToken, String.valueOf(memberId), refreshToken);
+    public static LoginResponseDto of(String accessToken, Long memberId, String refreshToken, boolean isRegistered) {
+        return new LoginResponseDto(
+                accessToken,
+                String.valueOf(memberId),
+                refreshToken,
+                isRegistered
+        );
     }
 }
 

--- a/backend/src/main/java/com/backend/global/auth/kakao/dto/LoginResponseDto.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/dto/LoginResponseDto.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 @Builder
 public record LoginResponseDto(
         String accessToken,
+        String kakaoId,
         String memberId,
         String refreshToken,
         boolean isRegistered
@@ -17,16 +18,18 @@ public record LoginResponseDto(
     /**
      * 응답 객체 생성 메서드
      *
-     * @param accessToken   발급된 액세스 토큰
-     * @param memberId      회원 ID (String으로 변환)
-     * @param refreshToken  발급된 리프레시 토큰
-     * @param isRegistered  기존 회원 여부
+     * @param accessToken  발급된 액세스 토큰
+     * @param kakaoId      카카오 회원 ID (String으로 변환)
+     * @param memberId     멤버 ID (PK)
+     * @param refreshToken 발급된 리프레시 토큰
+     * @param isRegistered 기존 회원 여부
      * @return 응답 DTO
      */
-    public static LoginResponseDto of(String accessToken, Long memberId, String refreshToken, boolean isRegistered) {
+    public static LoginResponseDto of(String accessToken, Long kakaoId, Long memberId, String refreshToken, boolean isRegistered) {
         return new LoginResponseDto(
                 accessToken,
-                String.valueOf(memberId),
+                String.valueOf(kakaoId),
+                memberId != null ? String.valueOf(memberId) : null,
                 refreshToken,
                 isRegistered
         );

--- a/backend/src/main/java/com/backend/global/auth/kakao/service/KakaoAuthService.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/service/KakaoAuthService.java
@@ -136,7 +136,7 @@ public class KakaoAuthService {
         cookieService.addRefreshTokenToCookie(refreshToken, response);
 
         // 7. 응답 DTO 반환
-        return LoginResponseDto.of(accessToken, member.getId(), refreshToken, isRegistered);
+        return LoginResponseDto.of(accessToken, kakaoId, isRegistered ? member.getId() : null, refreshToken, isRegistered);
     }
 
     /**
@@ -156,7 +156,7 @@ public class KakaoAuthService {
             member.updateRefreshToken(newToken.refreshToken());
         }
 
-        return LoginResponseDto.of(newToken.accessToken(), member.getId(), newToken.refreshToken(), true);
+        return LoginResponseDto.of(newToken.accessToken(), member.getKakaoId(), member.getId(), newToken.refreshToken(), true);
 
     }
 }

--- a/backend/src/main/java/com/backend/global/auth/kakao/service/KakaoAuthService.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/service/KakaoAuthService.java
@@ -1,6 +1,5 @@
 package com.backend.global.auth.kakao.service;
 
-import com.backend.domain.member.dto.MemberRegisterRequestDto;
 import com.backend.domain.member.entity.Member;
 import com.backend.domain.member.repository.MemberRepository;
 import com.backend.domain.member.service.MemberService;
@@ -10,14 +9,14 @@ import com.backend.global.auth.kakao.dto.LoginResponseDto;
 import com.backend.global.auth.kakao.util.JwtUtil;
 import com.backend.global.auth.kakao.util.KakaoAuthUtil;
 import com.backend.global.auth.kakao.util.TokenProvider;
-import com.backend.global.exception.GlobalErrorCode;
-import com.backend.global.exception.GlobalException;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Optional;
 
 /**
  * 카카오 인가 코드를 받아 회원 정보를 조회하고 JWT 토큰을 발급하는 인증 서비스
@@ -95,20 +94,34 @@ public class KakaoAuthService {
         Long kakaoId = kakaoUserInfo.id();
 
         // 3. 해당 kakaoId가 등록된 사용자인지 확인 (회원인지 아닌지 확인)
-        Member member = memberRepository.findByKakaoId(kakaoId).orElse(null);
+//        Member member = memberRepository.findByKakaoId(kakaoId).orElse(null);
+        Optional<Member> optionalMember = memberRepository.findByKakaoId(kakaoId);
+        boolean isRegistered = optionalMember.isPresent();
+        Member member;
 
-        if (member == null) {
-            // 3-1. 신규 사용자라면 registerMember 호출
-            MemberRegisterRequestDto registerDto = MemberRegisterRequestDto.fromKakao(kakaoUserInfo);
-            memberService.registerMember(registerDto);
-
-            // 등록 후 다시 조회
-            member = memberRepository.findByKakaoId(kakaoId)
-                    .orElseThrow(() -> new GlobalException(GlobalErrorCode.MEMBER_REGISTRATION_FAILED));
-        } else {
-            // 3-2. 기존 회원이면 카카오 토큰 업데이트
+        if (isRegistered) {
+            // 3-1. 기존 회원이면 토큰 업데이트
+            member = optionalMember.get();
             member.updateAccessToken(kakaoAccessToken);
             member.updateRefreshToken(kakaoRefreshToken);
+        } else {
+            // 3-2. 신규 회원 → 아직 DB에는 등록하지 않음 (회원가입 전 단계)
+            // 이후 /members/register 에서 최종 등록 예정
+            // 신규 유저면 DB에 등록하지 않고 member 객체만 생성
+            member = Member.ofKakaoUser(
+                    kakaoId,
+                    kakaoUserInfo.kakaoAccount().email(),
+                    kakaoUserInfo.properties().nickname()
+
+            );
+            /* 방법2: builder를 해서 선택적으로 필드에 값을 넣고 객체로 데이터를 넘겨주는 방법
+            member = Member.builder()
+                    .kakaoId(kakaoId)
+                    .nickname(kakaoUserInfo.properties().nickname())
+                    .email(kakaoUserInfo.kakaoAccount().email())
+                    .build();
+
+             */
         }
 
         // 4. JWT access, refresh 토큰 생성
@@ -123,7 +136,7 @@ public class KakaoAuthService {
         cookieService.addRefreshTokenToCookie(refreshToken, response);
 
         // 7. 응답 DTO 반환
-        return LoginResponseDto.of(accessToken, member.getId(), refreshToken);
+        return LoginResponseDto.of(accessToken, member.getId(), refreshToken, isRegistered);
     }
 
     /**
@@ -143,7 +156,7 @@ public class KakaoAuthService {
             member.updateRefreshToken(newToken.refreshToken());
         }
 
-        return LoginResponseDto.of(newToken.accessToken(), member.getId(), newToken.refreshToken());
+        return LoginResponseDto.of(newToken.accessToken(), member.getId(), newToken.refreshToken(), true);
 
     }
 }

--- a/backend/src/main/java/com/backend/global/exception/GlobalErrorCode.java
+++ b/backend/src/main/java/com/backend/global/exception/GlobalErrorCode.java
@@ -33,12 +33,12 @@ public enum GlobalErrorCode {
 	// 정리 필요
 	SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 오류가 발생했습니다."),
 	INVALID_REQUEST(HttpStatus.BAD_REQUEST, 400, "잘못된 요청입니다."),
-	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 401-1, "유효하지 않은 토큰입니다."),
-	TOKEN_REISSUE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 401-2, "토큰 갱신에 실패했습니다."),
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 4011, "유효하지 않은 토큰입니다."),
+	TOKEN_REISSUE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 4012, "토큰 갱신에 실패했습니다."),
 	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, 402, "토큰이 만료되었습니다."),
 	UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, 403, "지원하지 않는 JWT 입니다."),
 	REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, 404, "리프레시 토큰이 존재하지 않습니다."),
-	MEMBER_REGISTRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500-1, "멤버를 찾을 수 없습니다.");
+	MEMBER_REGISTRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5001, "멤버를 찾을 수 없습니다.");
 
 
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,3 +3,11 @@ spring:
     active: local
   application:
     name: backend
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true
+


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) [FEAT] : pull request template #17-->

우리 서비스 아키텍쳐에 맞게 카카오 로그인/회원가입 기능의 로직을 리팩토링

**서비스 흐름**
1. 카카오 로그인 시도
- code(인가 코드)로 로그인 요청 → 카카오에서 access_token, refresh_token 획득
- 카카오 사용자 정보 (id, email, nickname) 가져오기

2. 회원 존재 여부 확인
- MemberRepository.findByKakaoId() 통해 기존 회원인지 체크
- 존재하면 → 바로 LoginResponseDto 반환 (토큰 세팅 및 쿠키 설정)
- 존재하지 않으면 → 신규 유저 → isRegistered = false 로 응답하여, 프론트에서 추가 회원가입 유도

3. 회원 가입
프론트에서 MemberRegisterRequestDto 로 입력 값 (키, 나이, 성별, 위도/경도 등) 받아서 POST
백엔드에서는 MemberService.registerMember() 통해 해당 유저 정보를 저장

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)

  <br/>

## ✔️PR Checklist
- [ ] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?

  <br/>

## 🔎 작업 내용
우리 서비스 아키텍쳐에 맞게 카카오 로그인/회원가입 기능의 로직을 리팩토링
KakaoAuthService 클래스 의 processLogin 메서드
LoginResponseDto 수정

<!--resolves #{Issue번호} + Enter
ex) resolves #17
ex) close #17
이슈와 PR 연결을 위해 사용합니다!-->
close #22 


  <br/>

## 📈이미지 첨부
