### PR TITLE
[Refactor] 카카오 로그인/회원가입 로직을 /callback 중심으로 통합 및 보안 흐름 개선

### DIFF
--- a/backend/src/main/java/com/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/com/backend/domain/member/entity/Member.java
@@ -3,24 +3,10 @@ package com.backend.domain.member.entity;
 import com.backend.domain.image.entity.Image;
 import com.backend.domain.member.dto.MemberRegisterRequestDto;
 import com.backend.global.base.BaseEntity;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -87,26 +73,6 @@ public class Member extends BaseEntity {
                 .chatAble(true)
                 .role(role)
                 .build();
-    }
-
-    @Builder
-    public Member(Long kakaoId, String email, String nickname,
-                  Integer age, Integer height, String gender,
-                  List<Image> images, Boolean chatAble,
-                  Double latitude, Double longitude,
-                  Role role) {
-
-        this.kakaoId = kakaoId;
-        this.email = email;
-        this.nickname = nickname;
-        this.age = age;
-        this.height = height;
-        this.gender = gender;
-        this.images = images;
-        this.chatAble = chatAble;
-        this.latitude = latitude;
-        this.longitude = longitude;
-        this.role = role;
     }
 
     public void updateProfile(String nickname, Integer age, Integer height, String gender,

--- a/backend/src/main/java/com/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/backend/domain/member/service/MemberService.java
@@ -1,11 +1,5 @@
 package com.backend.domain.member.service;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.backend.domain.member.dto.MemberInfoDto;
 import com.backend.domain.member.dto.MemberModifyRequestDto;
 import com.backend.domain.member.dto.MemberRegisterRequestDto;
@@ -16,8 +10,12 @@ import com.backend.domain.member.repository.MemberRepository;
 import com.backend.global.exception.GlobalErrorCode;
 import com.backend.global.exception.GlobalException;
 import com.backend.global.redis.service.RedisGeoService;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -79,7 +77,7 @@ public class MemberService {
                     requestDto.height(),            // 추가 정보: 키
                     requestDto.gender(),            // 추가 정보: 성별
                     member.getImages(),             // 기존 이미지 리스트 유지 (필요 시 별도 수정)
-                    member.getChatAble(),           // 기존 chatAble 유지
+                    member.isChatAble(),           // 기존 chatAble 유지
                     requestDto.latitude(),          // 추가 정보: 위도
                     requestDto.longitude()          // 추가 정보: 경도
                 );

--- a/backend/src/main/java/com/backend/global/auth/kakao/controller/KakaoAuthController.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/controller/KakaoAuthController.java
@@ -53,15 +53,17 @@ public class KakaoAuthController {
     }
 
 
-    /**
-     * 로그인 API (인가코드로 로그인 및 회원가입 처리)
-     * 	프론트에서 code 받아 백엔드로 POST
-     */
-    @PostMapping("/login")
-    public ResponseEntity<LoginResponseDto> kakaoLogin(@RequestParam String code, HttpServletResponse response) {
-        LoginResponseDto loginResult = kakaoAuthService.processLogin(code, response);
-        return ResponseEntity.ok(loginResult);
-    }
+//    /**
+//     * 로그인 API (인가코드로 로그인 및 회원가입 처리)
+//     * 	프론트에서 code 받아 백엔드로 POST
+//     */
+//    @PostMapping("/login")
+//    public ResponseEntity<LoginResponseDto> kakaoLogin(@RequestParam String code, HttpServletResponse response) {
+//        LoginResponseDto loginResult = kakaoAuthService.processLogin(code, response);
+//        cookieService.addAccessTokenToCookie(loginResult.accessToken(), response);
+//        cookieService.addRefreshTokenToCookie(loginResult.refreshToken(), response);
+//        return ResponseEntity.ok(loginResult);
+//    }
 
     /**
      * 프론트 리다이렉트용 콜백 핸들러
@@ -69,7 +71,19 @@ public class KakaoAuthController {
      * 	카카오 서버가 직접 리다이렉트
      */
     @GetMapping("/callback")
-    public ResponseEntity<GenericResponse<LoginResponseDto>> loginCallback(@RequestParam String code, HttpServletResponse response) {
+    public ResponseEntity<GenericResponse<LoginResponseDto>> loginCallback(
+            @RequestParam(required = false) String code,
+            @RequestParam(required = false) String error,
+            @RequestParam(required = false, name = "error_description") String errorDescription,
+            HttpServletResponse response) {
+
+        // 카카오 로그인 실패 시 예외 처리
+        if (error != null) {
+            throw new GlobalException(GlobalErrorCode.KAKAO_LOGIN_FAILED,
+                    "카카오 로그인 실패: " + (errorDescription != null ? errorDescription : error));
+        }
+
+        // 카카오 로그인 정상 처리시
         LoginResponseDto loginResult = kakaoAuthService.processLogin(code, response);
 
         cookieService.addAccessTokenToCookie(loginResult.accessToken(), response);

--- a/backend/src/main/java/com/backend/global/auth/kakao/util/KakaoAuthUtil.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/util/KakaoAuthUtil.java
@@ -33,6 +33,12 @@ public class KakaoAuthUtil {
     @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
     private String USER_INFO_URI;
 
+    @Value("${kakao.logout-url}")
+    private String KAKAO_LOGOUT_URL;
+
+    @Value("${kakao.logout-redirect-uri}")
+    private String KAKAO_LOGOUT_REDIRECT_URI;
+
     // 사용자가 카카오 로그인 버튼 클릭 시 리디렉션될 인가 코드 요청 URL
     public String getKakaoAuthorizationUrl() {
         return UriComponentsBuilder.fromUriString(AUTH_URI)
@@ -63,6 +69,15 @@ public class KakaoAuthUtil {
                 .queryParam("grant_type", "refresh_token")
                 .queryParam("client_id", CLIENT_ID)
                 .queryParam("refresh_token", refreshToken)
+                .toUriString();
+    }
+
+    public String getLogoutUrl(Long userId) {
+
+        return UriComponentsBuilder.fromUriString(KAKAO_LOGOUT_URL)
+                .queryParam("client_id", CLIENT_ID)
+                .queryParam("logout_redirect_uri", KAKAO_LOGOUT_REDIRECT_URI)
+                .queryParam("state", userId)
                 .toUriString();
     }
 }

--- a/backend/src/main/java/com/backend/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/backend/global/config/SwaggerConfig.java
@@ -36,7 +36,7 @@ public class SwaggerConfig {
                                                 .tokenUrl("https://kauth.kakao.com/oauth/token")
                                                 .scopes(new Scopes()
                                                         .addString("profile_nickname", "사용자 닉네임")
-                                                        .addString("profile_image", "프로필 이미지")
+//                                                        .addString("profile_image", "프로필 이미지")
                                                         .addString("account_email", "이메일"))))));
     }
 

--- a/backend/src/main/java/com/backend/global/exception/GlobalErrorCode.java
+++ b/backend/src/main/java/com/backend/global/exception/GlobalErrorCode.java
@@ -13,6 +13,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum GlobalErrorCode {
 
+	// 카카오 로그인 에러
+	KAKAO_LOGIN_FAILED(HttpStatus.BAD_REQUEST, 400, "카카오 로그인 중 에러가 발생했습니다."),
+
 
 	// 이미지 도메인 세부 에러
 	IMAGE_COUNT_INVALID(HttpStatus.BAD_REQUEST, 400, "이미지는 1장 이상 5장 이하로 등록해야 합니다."),


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) [FEAT] : pull request template #17-->
카카오 로그인/회원가입 로직을 /callback 중심으로 통합 및 보안 흐름 개선
close #39 
## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra


## ✔️PR Type
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)


## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?


## 🔎 작업 내용

<!--resolves #{Issue번호} + Enter
- 기존의 `/api/auth/kakao/login` API 제거
  - 프론트에서 직접 인가 코드를 받아 전달하던 구조 삭제
- `/api/auth/kakao/callback` API 중심으로 통합
- `error`, `error_description` 파라미터 처리 로직 추가
  - 카카오 로그인 취소 시 예외 반환 (`GlobalErrorCode.KAKAO_LOGIN_FAILED`)


## 📈이미지 첨부
