### PR TITLE
[Fix] 회원가입 이후에도 ROLE_TEMP_USER로 발급받은 토큰으로 남아있어 발생하던 추가정보 입력이 필요합니다 오류 해결

### DIFF
--- a/backend/src/main/java/com/backend/domain/member/dto/MemberInfoDto.java
+++ b/backend/src/main/java/com/backend/domain/member/dto/MemberInfoDto.java
@@ -1,11 +1,11 @@
 package com.backend.domain.member.dto;
 
-import java.util.List;
-
 import com.backend.domain.image.entity.Image;
 import com.backend.domain.member.entity.Member;
-
+import com.backend.domain.member.entity.Role;
 import lombok.Builder;
+
+import java.util.List;
 
 /**
  * 서비스 내부 전용 DTO로 설계
@@ -24,7 +24,8 @@ public record MemberInfoDto(
         Boolean chatAble,
         List<Image> images,
         Double latitude,
-        Double longitude
+        Double longitude,
+        Role role
 ) {
     public static MemberInfoDto from(Member member) {
         return new MemberInfoDto(
@@ -38,7 +39,8 @@ public record MemberInfoDto(
                 member.isChatAble(),
                 member.getImages(),
                 member.getLatitude(),
-                member.getLongitude()
+                member.getLongitude(),
+                member.getRole()
         );
     }
 }

--- a/backend/src/main/java/com/backend/domain/member/dto/MemberModifyRequestDto.java
+++ b/backend/src/main/java/com/backend/domain/member/dto/MemberModifyRequestDto.java
@@ -1,14 +1,13 @@
 package com.backend.domain.member.dto;
 
-import java.util.List;
-
-import org.hibernate.validator.constraints.Length;
-
 import com.backend.domain.image.entity.Image;
-
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
+import org.hibernate.validator.constraints.Length;
+
+import java.util.List;
 
 
 /**
@@ -30,7 +29,7 @@ public record MemberModifyRequestDto(
         @NotBlank(message = "성별은 필수입니다.")
         String gender,
 
-        @NotBlank(message = "프로필 이미지는 필수입니다.")
+        @NotEmpty(message = "프로필 이미지는 필수입니다.")
         List<Image> images,
 
         // 위도, 경도 정보

--- a/backend/src/main/java/com/backend/domain/member/dto/MemberRegisterResponseDto.java
+++ b/backend/src/main/java/com/backend/domain/member/dto/MemberRegisterResponseDto.java
@@ -1,0 +1,14 @@
+package com.backend.domain.member.dto;
+
+/**
+ * 회원 가입 완료 후 클라이언트에 반환할 응답 DTO
+ * - 회원 정보
+ * - JWT accessToken
+ * - JWT refreshToken 포함
+ */
+
+public record MemberRegisterResponseDto(
+        MemberInfoDto member,
+        String accessToken,
+        String refreshToken
+) {}


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) [FEAT] : pull request template #17-->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## ✔️PR Type
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)


## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?


## 🔎 작업 내용

close #46 

회원가입 이후에도 ROLE_TEMP_USER로 발급받은 토큰으로 남아있어 발생하던 "추가 정보 입력이 필요합니다" 오류 해결.
클라이언트에서 재발급된 토큰을 쿠키에 반영하지 못해 발생하던 인증 오류 해결

- 카카오 소셜 로그인 후 /api/members/register 엔드포인트에서 사용자 정보 등록이 완료되면, 기존 ROLE_TEMP_USER → ROLE_USER로 권한이 변경되도록 구현
- 권한 변경에 따른 JWT AccessToken, RefreshToken 재발급 로직 추가 및 발급된 토큰을 쿠키에 다시 업데이트해서 저장하여 이후 인증 요청에 반영되도록 개선


## 📈이미지 첨부
