### PR TITLE
[Feature] Refresh Token에 대한 보안 강화 및 Redis에 저장되는 로직을 개선하여 보안 강화

### DIFF
--- a/backend/src/main/java/com/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/backend/domain/member/controller/MemberController.java
@@ -67,7 +67,7 @@ public class MemberController {
         // 3. 최신 회원 정보를 다시 조회하여 반환 (profileImage 등 업데이트 반영)
         MemberInfoDto updatedInfo = memberService.getMemberInfo(memberInfo.id());
 
-        // 🔑 4. 토큰 재발급 (ROLE_TEMP_USER -> ROLE_USER 로 role 변경시 토큰 재발급이 필요)
+        // 4. 토큰 재발급 (ROLE_TEMP_USER -> ROLE_USER 로 role 변경시 토큰 재발급이 필요)
         String accessToken = tokenProvider.createAccessToken(updatedInfo.id(), updatedInfo.role().name());
         String refreshToken = tokenProvider.createRefreshToken(updatedInfo.id());
 

--- a/backend/src/main/java/com/backend/global/auth/jwt/JwtFilter.java
+++ b/backend/src/main/java/com/backend/global/auth/jwt/JwtFilter.java
@@ -54,7 +54,7 @@ public class JwtFilter extends OncePerRequestFilter {
             } catch (Exception e) {
                 // 인증 실패 → SecurityContextHolder에 아무것도 안 넣고 넘어감
                 // 토큰이 유효하지 않아도, Swagger나 로그인 페이지처럼 비회원도 접근해야 하는 리소스에 대한 접근 허용
-                log.warn("⚠️ JWT 토큰이 유효하지 않음: {}", e.getMessage());
+                log.warn("⚠️ [JwtFilter] JWT 토큰이 유효하지 않음: {}", e.getMessage());
             }
         }
         // 3. 다음 필터로 이동

--- a/backend/src/main/java/com/backend/global/auth/kakao/controller/KakaoAuthController.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/controller/KakaoAuthController.java
@@ -69,12 +69,14 @@ public class KakaoAuthController {
      * 프론트 리다이렉트용 콜백 핸들러
      * 로그인 후 콜백 요청 처리 (액세스/리프레시 토큰을 쿠키에 설정)
      * 	카카오 서버가 직접 리다이렉트
+     * 	로그인 후 콜백 시 HttpServletRequest 추가
      */
     @GetMapping("/callback")
     public ResponseEntity<GenericResponse<LoginResponseDto>> loginCallback(
             @RequestParam(required = false) String code,
             @RequestParam(required = false) String error,
             @RequestParam(required = false, name = "error_description") String errorDescription,
+            HttpServletRequest request,
             HttpServletResponse response) {
 
         // 카카오 로그인 실패 시 예외 처리
@@ -84,7 +86,7 @@ public class KakaoAuthController {
         }
 
         // 카카오 로그인 정상 처리시
-        LoginResponseDto loginResult = kakaoAuthService.processLogin(code, response);
+        LoginResponseDto loginResult = kakaoAuthService.processLogin(code, request, response);
 
         cookieService.addAccessTokenToCookie(loginResult.accessToken(), response);
         cookieService.addRefreshTokenToCookie(loginResult.refreshToken(), response);
@@ -98,15 +100,20 @@ public class KakaoAuthController {
     @PostMapping("/reissue")
     public ResponseEntity<LoginResponseDto> reissue(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = cookieService.getRefreshTokenFromCookie(request);
-
         tokenProvider.validateToken(refreshToken);
-        Long memberId = tokenProvider.parseToken(refreshToken).get("id", Long.class);
 
-        if (!redisRefreshTokenService.isValid(memberId, refreshToken)) {
+        Long memberId = tokenProvider.parseToken(refreshToken).get("id", Long.class);
+        String jti = tokenProvider.parseToken(refreshToken).getId();
+        String ip = request.getRemoteAddr();
+        String userAgent = request.getHeader("User-Agent");
+
+        // Redis에서 저장된 refreshToken과 일치하는지 확인 (화이트리스트 방식)
+        if (!redisRefreshTokenService.isValid(memberId, jti, refreshToken, ip, userAgent)) {
             throw new GlobalException(GlobalErrorCode.TOKEN_EXPIRED);
         }
 
-        LoginResponseDto newToken = kakaoAuthService.reissueTokens(refreshToken);
+        // reissueTokens 메서드에 HttpServletRequest 전달
+        LoginResponseDto newToken = kakaoAuthService.reissueTokens(refreshToken, request);
 
         // 리프레시 토큰이 갱신되었다면 쿠키에 반영
         if (newToken.refreshToken() != null) {
@@ -122,9 +129,19 @@ public class KakaoAuthController {
     @PostMapping("/logout")
     // AuthenticationPrincipal CustomUserDetails를 통해 인증된 사용자 정보 가져옴
     public ResponseEntity<Void> logout(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                       HttpServletRequest request,
                                        HttpServletResponse response) {
         Long memberId = userDetails.getMemberId(); // 인증 정보에서 ID 추출
-        redisRefreshTokenService.deleteRefreshToken(memberId);
+
+        String refreshToken = cookieService.getRefreshTokenFromCookie(request);
+        if (refreshToken != null) {
+            String jti = tokenProvider.parseToken(refreshToken).getId();
+            redisRefreshTokenService.deleteRefreshToken(memberId, jti);
+            log.info("[Logout] 로그아웃한 회원 {}에 대한 리프레시 토큰(jti: {}) 삭제 완료.", memberId, jti);
+        } else {
+            log.warn("[Logout] 로그아웃한 회원 {}의 리프레시 토큰을 찾을 수 없습니다.", memberId);
+        }
+
         cookieService.clearTokensFromCookie(response);
         return ResponseEntity.ok().build();
     }
@@ -134,27 +151,41 @@ public class KakaoAuthController {
      */
     @GetMapping("/refresh")
     public ResponseEntity<LoginResponseDto> refreshToken(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                         HttpServletRequest request) {
+                                                         HttpServletRequest request,
+                                                         HttpServletResponse response) {
         String refreshToken = cookieService.getRefreshTokenFromCookie(request);
         Long memberId = userDetails.getMemberId(); // 인증 정보에서 ID 추출
-
         tokenProvider.validateToken(refreshToken);
 
-        if (!redisRefreshTokenService.isValid(memberId, refreshToken)) {
-            throw new GlobalException(GlobalErrorCode.TOKEN_EXPIRED);
+        String jti = tokenProvider.parseToken(refreshToken).getId();
+        String ip = request.getRemoteAddr();
+        String userAgent = request.getHeader("User-Agent");
+
+        // Redis에서 저장된 refreshToken과 일치하는지 확인 (화이트리스트 방식)
+        if (!redisRefreshTokenService.isValid(memberId, jti, refreshToken, ip, userAgent)) {
+            throw new GlobalException(GlobalErrorCode.INVALID_TOKEN); // 같지 않으면 예외 처리
         }
 
+        // 새로운 AccessToken 발급
         String role = userDetails.getAuthorities().stream()
                 .findFirst()
                 .map(Object::toString)
-                .orElseThrow(() -> new GlobalException(GlobalErrorCode.INVALID_TOKEN));
+                .orElseThrow(() -> new GlobalException(GlobalErrorCode.INVALID_TOKEN)); // 같지 않으면 예외 처리
 
-        String newAccessToken = tokenProvider.createAccessToken(memberId, role);
+        String newAccessToken = tokenProvider.createAccessToken(memberId, role); // AccessToken 발급
 
-        // 필요한 kakaoId 조회
+        // refreshToken도 자주 갱신 (덮어쓰기)
+        String newRefreshToken = tokenProvider.createRefreshToken(memberId);
+        long refreshTokenExpiration = tokenProvider.getRefreshTokenExpiration(); // refresh token 유효기간 가져오기
+
+        // 새 refreshToken 정보 저장 (jti 및 클라이언트 정보 포함)
+        String newJti = tokenProvider.parseToken(newRefreshToken).getId();
+        redisRefreshTokenService.saveRefreshToken(memberId, newJti, newRefreshToken, refreshTokenExpiration, ip, userAgent);
+        cookieService.addRefreshTokenToCookie(newRefreshToken, response);
+
         Member member = memberService.getByKakaoId(memberId);
         return ResponseEntity.ok(LoginResponseDto.of(newAccessToken, member.getKakaoId(), memberId
-                , refreshToken, true));
+                , newRefreshToken, true));
     }
 
 }

--- a/backend/src/main/java/com/backend/global/auth/kakao/service/RedisRefreshTokenService.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/service/RedisRefreshTokenService.java
@@ -1,17 +1,20 @@
 package com.backend.global.auth.kakao.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 
 /**
- * Redis를 활용하여 리프레시 토큰을 저장, 검증, 삭제하는 서비스
- * - 저장 시 만료시간을 함께 설정함
- * - 저장 키는 "RT:{memberId}" 형식으로 구성됨
+ * Redis를 활용하여 리프레시 토큰과 클라이언트 식별정보(IP, User-Agent)를 저장, 검증, 삭제하는 서비스
+ * - 저장 시 고유 식별자(jti)를 포함한 키("RT:{memberId}:{jti}")를 사용하여 각 토큰별로 관리합
+ * - 토큰과 함께 해당 클라이언트의 IP, User-Agent 정보를 저장하여 이후 검증 시 활용할 수 있다.
+ * - 저장 시 만료시간을 함께 설정하여 자동 만료되도록 한다.
  */
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RedisRefreshTokenService {
@@ -19,41 +22,80 @@ public class RedisRefreshTokenService {
     private final StringRedisTemplate redisTemplate;
 
     /**
-     * 리프레시 토큰을 Redis에 저장
-     * @param memberId 사용자 ID
-     * @param token 저장할 리프레시 토큰
+     * @param memberId   사용자 ID
+     * @param jti        JWT의 고유 식별자 (refreshToken의 jti)
+     * @param token      저장할 리프레시 토큰
      * @param expiration 토큰 만료시간 (밀리초)
+     * @param ip         클라이언트의 IP 주소
+     * @param userAgent  클라이언트의 User-Agent
      */
-    public void saveRefreshToken(Long memberId, String token, long expiration) {
-        redisTemplate.opsForValue().set(getKey(memberId), token, Duration.ofMillis(expiration));
+    public void saveRefreshToken(Long memberId, String jti, String token, long expiration, String ip, String userAgent) {
+        String key = getKey(memberId, jti);
+        String value = token + "|" + ip + "|" + userAgent;
+        redisTemplate.opsForValue().set(key, value, Duration.ofMillis(expiration));
     }
 
     /**
-     * 저장된 리프레시 토큰이 유효한지 검증
-     * @param memberId 사용자 ID
-     * @param token 요청에서 받은 리프레시 토큰
-     * @return 토큰이 일치하면 true
+     * 저장된 리프레시 토큰과 클라이언트 정보를 검증
+     *
+     * @param memberId         사용자 ID
+     * @param jti              JWT의 고유 식별자 (refreshToken의 jti)
+     * @param token            요청에서 받은 리프레시 토큰
+     * @param currentIp        현재 요청의 클라이언트 IP 주소
+     * @param currentUserAgent 현재 요청의 클라이언트 User-Agent
+     * @return 저장된 토큰, IP, User-Agent 정보가 요청 정보와 일치하면 true, 그렇지 않으면 false
      * 화이트리스트 방식: Redis에 허용된 refreshToken만 저장하고, 요청이 들어오면 이 토큰이 존재하는지 확인하는 구조
      */
-    public boolean isValid(Long memberId, String token) {
-        String storedToken = redisTemplate.opsForValue().get(getKey(memberId));
-        return storedToken != null && storedToken.equals(token);
+    public boolean isValid(Long memberId, String jti, String token, String currentIp, String currentUserAgent) {
+        String key = getKey(memberId, jti);
+        String storedData = redisTemplate.opsForValue().get(key);
+
+        if (storedData == null) {
+            log.warn("[RedisRefreshTokenService] 키 {} 에 저장된 토큰이 존재하지 않습니다.", key);
+            return false;
+        }
+
+        // storedData 형식: refreshToken|ip|userAgent
+        String[] parts = storedData.split("\\|");
+        if (parts.length != 3) {
+            log.warn("[RedisRefreshTokenService] 키 {} 에 저장된 토큰 형식이 올바르지 않습니다.", key);
+            return false;
+        }
+
+        String storedToken = parts[0];
+        String storedIp = parts[1];
+        String storedUserAgent = parts[2];
+
+        if (!storedToken.equals(token)) {
+            log.warn("[RedisRefreshTokenService] 키 {} 에서 토큰 불일치 발생. 저장된 토큰: {} / 제공된 토큰: {}", key, storedToken, token);
+            return false;
+        }
+        if (!storedIp.equals(currentIp) || !storedUserAgent.equals(currentUserAgent)) {
+            log.warn("[RedisRefreshTokenService] 키 {} 에서 클라이언트 정보 불일치 발생. 예상 IP/UserAgent: {}/{} / 실제 IP/UserAgent: {}/{}", key, storedIp, storedUserAgent, currentIp, currentUserAgent);
+            return false;
+        }
+        return true;
     }
+
 
     /**
      * Redis에서 리프레시 토큰 삭제
+     *
      * @param memberId 사용자 ID
+     * @param jti      JWT의 고유 식별자 (refreshToken의 jti)
      */
-    public void deleteRefreshToken(Long memberId) {
-        redisTemplate.delete(getKey(memberId));
+    public void deleteRefreshToken(Long memberId, String jti) {
+        redisTemplate.delete(getKey(memberId, jti));
     }
 
     /**
      * Redis에 저장될 키 형식 생성
+     *
      * @param memberId 사용자 ID
-     * @return "RT:{memberId}" 형식의 키
+     * @param jti      JWT의 고유 식별자
+     * @return "RT:{memberId}:{jti}" 형식의 키
      */
-    private String getKey(Long memberId) {
-        return "RT:" + memberId;
+    private String getKey(Long memberId, String jti) {
+        return "RT:" + memberId + ":" + jti;
     }
 }

--- a/backend/src/main/java/com/backend/global/auth/kakao/util/CookieUtil.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/util/CookieUtil.java
@@ -36,19 +36,19 @@ public class CookieUtil {
     public String getCookieValue(HttpServletRequest request, String name) {
         Cookie[] cookies = request.getCookies();
         if (cookies == null) {
-            log.warn("⚠️ [CookieUtil] No cookies found in request");
+            log.warn("⚠️ [CookieUtil] 요청에 쿠키가 존재하지 않습니다.");
             return null;
         }
 
         for (Cookie cookie : cookies) {
-            log.info("🔍 [CookieUtil] Cookie: name={}, value={}", cookie.getName(), cookie.getValue());
+            log.info("🔍 [CookieUtil] 쿠키 확인: name={}, value={}", cookie.getName(), cookie.getValue());
             if (cookie.getName().equals(name)) {
-                log.info("✅ [CookieUtil] Found target cookie '{}'", name);
+                log.info("✅ [CookieUtil] Target cookie '{}' 를 찾았습니다.", name);
                 return cookie.getValue();
             }
         }
 
-        log.warn("❌ [CookieUtil] Cookie '{}' not found in request", name);
+        log.warn("❌ [CookieUtil] 요청에서 쿠키 '{}' 를 찾을 수 없습니다.", name);
         return null;
     }
 

--- a/backend/src/main/java/com/backend/global/auth/kakao/util/KakaoAuthUtil.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/util/KakaoAuthUtil.java
@@ -73,7 +73,6 @@ public class KakaoAuthUtil {
     }
 
     public String getLogoutUrl(Long userId) {
-
         return UriComponentsBuilder.fromUriString(KAKAO_LOGOUT_URL)
                 .queryParam("client_id", CLIENT_ID)
                 .queryParam("logout_redirect_uri", KAKAO_LOGOUT_REDIRECT_URI)

--- a/backend/src/main/java/com/backend/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/backend/global/config/RedisConfig.java
@@ -7,11 +7,9 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
-@EnableRedisRepositories
 public class RedisConfig {
 
     // application.yml 파일에서 Redis 호스트 정보 주입

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
       - "3306:3306"
     volumes:
       - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   redis:
     image: redis:latest
@@ -21,8 +26,13 @@ services:
       - "6379:6379"
     volumes:
       - ./backend/infra/redis/redis.conf:/usr/local/etc/redis/redis.conf
-      - ./backend/infra/redis/data:/data # /data(redis) -> ./infra/redis/data(local) 저장
+      - ./backend/infra/redis/data:/data
     command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0
@@ -32,6 +42,12 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
+    healthcheck:
+      # netcat (nc) 명령어로 2181 포트 점검
+      test: ["CMD", "nc", "-z", "localhost", "2181"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   kafka:
     image: confluentinc/cp-kafka:7.5.0
@@ -44,6 +60,12 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    healthcheck:
+      # kafka 컨테이너의 9092 포트 점검; 컨테이너에 nc가 설치되어 있다면 사용
+      test: ["CMD", "nc", "-z", "localhost", "9092"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
 volumes:
   mysql_data:


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) [FEAT] : pull request template #17-->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra


## ✔️PR Type
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)


## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?


## 🔎 작업 내용


1. Refresh Token 관리 개선
- 토큰마다 고유한 jti를 생성해 Redis의 Key로 사용:
refreshToken 생성 시 UUID 기반의 고유 식별자(jti)를 부여하여 이를 통해 식별 가능하도록 처리하였고, JWT에 setId(jti)를 추가했습니다.
Redis에는 이제 "RT:{memberId}:{jti}" 형식의 키로 저장되어, 동일 회원의 토큰을 개별적으로 관리할 수 있습니다.

- 클라이언트 식별정보 추가 저장:
refreshToken과 함께 클라이언트의 IP 주소 및 User-Agent 정보를 Redis에 저장하여, 재발급 요청 시 현재 요청의 클라이언트 정보와 비교하도록 했습니다. 이를 통해 탈취된 토큰이 다른 환경에서 사용되는 것을 효과적으로 차단할 수 있습니다.

2. 로그아웃 처리 로직 개선
특정 토큰만 삭제: 로그아웃 시 쿠키에 저장된 refreshToken에서 jti를 추출하여 해당 토큰만 Redis에서 삭제하도록 수정했습니다.
이 방식은 다중 디바이스 환경에서 특정 디바이스의 토큰만 무효화할 수 있게 하여, 다른 기기의 로그인 상태는 유지됩니다.

3. 에러 처리 및 로깅 강화
Redis에서 저장된 토큰과 클라이언트의 IP/User-Agent 정보 불일치 시 경고 로그를 남겨, 보안 위협 및 토큰 탈취 상황을 신속히 파악할 수 있도록 했습니다.


=> 기대효과:
탈취된 토큰을 이용한 재발급 시도를 방어하는 등 토큰 관련 보안성이 강화되었으며, 다중 디바이스 환경에서도 유연한 토큰 관리가 가능.

✅ 토큰 탈취 대비 방안
RefreshToken 유효성 검증 강화하였습니다.
- Redis에 저장된 토큰 값과 요청에서 온 토큰을 비교하여 유효성 확인합니다.
- 탈취된 토큰이 Redis에 등록되지 않은 경우 → 재발급 차단이 가능합니다.
- refreshToken이 탈취되더라도 Redis에서 미등록된 jti는 거부 처리하고, accessToken 재발급 시 반드시 Redis의 jti 기반 유효성 검사를 거쳐야 합니다.

✅ 사용자 정보 기반 이력 추적
- Redis에 IP 주소, User-Agent 정보도 함께 저장하여 이력 추적이 가능합니다.
- 향후 관리자 페이지에서 토큰에 대한 이상 접근 탐지를 가능하게끔 하였습니다.

close #49 



## 📈이미지 첨부
