### PR TITLE
[Fix] 토큰 관련 엔드포인트의 응답 형식 및 로그아웃/재발급 로직 리팩토링

### DIFF
--- a/backend/src/main/java/com/backend/global/auth/kakao/controller/KakaoAuthController.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/controller/KakaoAuthController.java
@@ -88,6 +88,9 @@ public class KakaoAuthController {
 
     /**
      * 리프레시 토큰을 통해 새로운 액세스 토큰 재발급
+     * 클라이언트가 명시적으로 POST 요청을 보내어 토큰 재발급을 요청
+     * 요청 쿠키에서 refresh token을 추출한 후, 유효성을 검증하고, Redis에 저장된 토큰 정보와 비교
+     * 검증 통과 시, 새로운 액세스 토큰과 리프레시 토큰을 생성
      */
     @PostMapping("/reissue")
     public ResponseEntity<GenericResponse<LoginResponseDto>> reissue(HttpServletRequest request, HttpServletResponse response) {
@@ -147,6 +150,8 @@ public class KakaoAuthController {
 
     /**
      * 쿠키에서 리프레시 토큰을 기반으로 새로운 액세스 토큰 재발급
+     * 액세스 토큰이 만료되어 보안 컨텍스트(AuthenticationPrincipal)가 없는 상황에서도, 클라이언트의 refresh token 쿠키를 이용해 새 토큰을 발급
+     * 새로운 리프레시 토큰도 발급하여, Redis에 저장하고 쿠키에 업데이트
      */
     @GetMapping("/refresh")
     public ResponseEntity<GenericResponse<LoginResponseDto>> refreshToken(HttpServletRequest request,

--- a/backend/src/main/java/com/backend/global/auth/kakao/controller/KakaoAuthController.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/controller/KakaoAuthController.java
@@ -68,8 +68,8 @@ public class KakaoAuthController {
     /**
      * 프론트 리다이렉트용 콜백 핸들러
      * 로그인 후 콜백 요청 처리 (액세스/리프레시 토큰을 쿠키에 설정)
-     * 	카카오 서버가 직접 리다이렉트
-     * 	로그인 후 콜백 시 HttpServletRequest 추가
+     * 카카오 서버가 직접 리다이렉트
+     * 로그인 후 콜백 시 HttpServletRequest 추가
      */
     @GetMapping("/callback")
     public ResponseEntity<GenericResponse<LoginResponseDto>> loginCallback(
@@ -98,7 +98,7 @@ public class KakaoAuthController {
      * 리프레시 토큰을 통해 새로운 액세스 토큰 재발급
      */
     @PostMapping("/reissue")
-    public ResponseEntity<LoginResponseDto> reissue(HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<GenericResponse<LoginResponseDto>> reissue(HttpServletRequest request, HttpServletResponse response) {
         String refreshToken = cookieService.getRefreshTokenFromCookie(request);
         tokenProvider.validateToken(refreshToken);
 
@@ -120,7 +120,7 @@ public class KakaoAuthController {
             cookieService.addRefreshTokenToCookie(newToken.refreshToken(), response);
         }
 
-        return ResponseEntity.ok(newToken);
+        return ResponseEntity.ok(GenericResponse.of(newToken, "토큰 재발급 성공"));
     }
 
     /**

--- a/backend/src/main/java/com/backend/global/response/GenericResponse.java
+++ b/backend/src/main/java/com/backend/global/response/GenericResponse.java
@@ -1,5 +1,6 @@
 package com.backend.global.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +17,7 @@ import java.time.ZonedDateTime;
 public class GenericResponse<T> {
 
     private final ZonedDateTime timestamp;
+    @Getter(onMethod_ = { @JsonProperty("isSuccess") })
     private final boolean isSuccess;
     private final int code;
     private final T data;


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) [FEAT] : pull request template #17-->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra


## ✔️PR Type
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)


## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [ ] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?


## 🔎 작업 내용


토큰 관련 엔드포인트의 응답 형식 및 로그아웃/재발급 로직 리팩토링
- 통일된 응답 형식 적용
모든 엔드포인트(로그인 콜백, 토큰 재발급(reissue/refresh), 로그아웃)가 GenericResponse 클래스를 사용하도록 리팩토링했습니다.

- 토큰 재발급(Refresh) 엔드포인트 개선
만료된 access token 때문에 @AuthenticationPrincipal로 인증 정보가 주입되지 않는 상황을 고려하여, refreshToken 엔드포인트에서는 쿠키에 저장된 refresh token에서 직접 memberId를 추출하도록 수정했습니다.

- 로그아웃 로직 수정
로그아웃 요청 시 만료된 access token으로 인해 SecurityContext에 인증 정보가 없을 수 있으므로, logout 엔드포인트에서도 refresh token에서 memberId를 직접 추출하여 Redis에 저장된 refresh token을 삭제하도록 변경했습니다.

- GenericResponse 클래스에서 응답 값 success 대신 항상 isSuccess로 응답되게 수정
몇몇 컨트롤러 api 응답에서 success와 isSuccess가 혼용되고 있어서 isSuccess로 통일되게끔 수정하였습니다.

close #55 

## 📈이미지 첨부
