### PR TITLE
[Feature, Refactor, Fix] 회원가입 흐름을 하나의 트랜잭션으로 통합 처리, 응답되는 DTO 개선, 프로필 정보 수정 메서드 버그 수정

### DIFF
--- a/backend/src/main/java/com/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/backend/domain/member/controller/MemberController.java
@@ -2,7 +2,6 @@ package com.backend.domain.member.controller;
 
 import com.backend.domain.image.service.PresignedService;
 import com.backend.domain.member.dto.*;
-import com.backend.domain.member.entity.Member;
 import com.backend.domain.member.service.MemberService;
 import com.backend.domain.userkeyword.dto.request.UserKeywordSaveRequest;
 import com.backend.domain.userkeyword.service.UserKeywordService;
@@ -112,8 +111,7 @@ public class MemberController {
     public ResponseEntity<GenericResponse<MemberResponseDto>> getMyProfile(
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         MemberResponseDto responseDto = memberService.getMemberInfo(customUserDetails, customUserDetails.getMemberId());
-        Member member = memberService.getMemberEntity(customUserDetails.getMemberId());
-//        System.out.println("현재 유저 역할 : " + member.getRole());
+
         return ResponseEntity.ok().body(GenericResponse.of(responseDto, "자신의 프로필 조회가 완료되었습니다."));
     }
 

--- a/backend/src/main/java/com/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/backend/domain/member/controller/MemberController.java
@@ -113,7 +113,7 @@ public class MemberController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         MemberResponseDto responseDto = memberService.getMemberInfo(customUserDetails, customUserDetails.getMemberId());
         Member member = memberService.getMemberEntity(customUserDetails.getMemberId());
-        System.out.println("현재 유저 역할 : " + member.getRole());
+//        System.out.println("현재 유저 역할 : " + member.getRole());
         return ResponseEntity.ok().body(GenericResponse.of(responseDto, "자신의 프로필 조회가 완료되었습니다."));
     }
 
@@ -130,14 +130,15 @@ public class MemberController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @PathVariable Long id,
             @RequestPart("member") MemberModifyRequestDto dto,
+            @RequestPart(value = "keywordIds", required = false) UserKeywordSaveRequest keywordRequest,
             @RequestPart("keepImageId") String keepIdsJson,
             @RequestPart(value = "newImages", required = false) List<MultipartFile> newImages) throws IOException {
 
-        List<Long> keepIds = objectMapper.readValue(keepIdsJson, new TypeReference<>() {
-        });
-        Member member = memberService.getMemberEntity(customUserDetails.getMemberId());
-        System.out.println(member.getRole());
-        MemberResponseDto res = memberService.modifyMember(id, dto, keepIds, newImages);
+        List<Long> keepIds = objectMapper.readValue(keepIdsJson, new TypeReference<>() { });
+
+        MemberResponseDto res = memberService.modifyMember(id, dto, keywordRequest, keepIds, newImages);
+
+
         return ResponseEntity.ok(GenericResponse.of(res, "회원 정보 수정 완료"));
     }
 

--- a/backend/src/main/java/com/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/backend/domain/member/controller/MemberController.java
@@ -66,7 +66,11 @@ public class MemberController {
         }
 
         // 1. 회원 기본 정보로 회원 생성 (이미지 정보는 없음)
-        MemberInfoDto memberInfo = memberService.registerMember(requestDto);
+        MemberInfoDto memberInfo = memberService.registerMember(
+                requestDto,
+                List.of(files),
+                userKeywordRequest.getKeywordIds(),
+                response);
 
         // 2. 이미지 파일들을 PresignedService.uploadFiles()를 통해 S3 업로드 및 DB 등록
         //    여기서는 List<MultipartFile>가 필요하므로 배열을 List로 변환합니다.

--- a/backend/src/main/java/com/backend/domain/member/dto/MemberInfoDto.java
+++ b/backend/src/main/java/com/backend/domain/member/dto/MemberInfoDto.java
@@ -3,6 +3,7 @@ package com.backend.domain.member.dto;
 import com.backend.domain.image.dto.ImageResponseDto;
 import com.backend.domain.member.entity.Member;
 import com.backend.domain.member.entity.Role;
+import com.backend.domain.userkeyword.dto.response.UserKeywordResponse;
 import lombok.Builder;
 
 import java.util.List;
@@ -27,9 +28,10 @@ public record MemberInfoDto(
         Double latitude,
         Double longitude,
         Role role,
-        String introduction
+        String introduction,
+        List<UserKeywordResponse> keywords
 ) {
-    public static MemberInfoDto from(Member member) {
+    public static MemberInfoDto from(Member member, List<UserKeywordResponse> keywords) {
         return new MemberInfoDto(
                 member.getId(),
                 member.getKakaoId(),
@@ -45,7 +47,8 @@ public record MemberInfoDto(
                 member.getLatitude(),
                 member.getLongitude(),
                 member.getRole(),
-                member.getIntroduction()
+                member.getIntroduction(),
+                keywords
         );
     }
 }

--- a/backend/src/main/java/com/backend/domain/member/dto/MemberInfoDto.java
+++ b/backend/src/main/java/com/backend/domain/member/dto/MemberInfoDto.java
@@ -26,7 +26,8 @@ public record MemberInfoDto(
         List<ImageResponseDto> images,
         Double latitude,
         Double longitude,
-        Role role
+        Role role,
+        String introduction
 ) {
     public static MemberInfoDto from(Member member) {
         return new MemberInfoDto(
@@ -43,7 +44,8 @@ public record MemberInfoDto(
                         .collect(Collectors.toList()),
                 member.getLatitude(),
                 member.getLongitude(),
-                member.getRole()
+                member.getRole(),
+                member.getIntroduction()
         );
     }
 }

--- a/backend/src/main/java/com/backend/domain/member/dto/MemberModifyRequestDto.java
+++ b/backend/src/main/java/com/backend/domain/member/dto/MemberModifyRequestDto.java
@@ -1,12 +1,9 @@
 package com.backend.domain.member.dto;
 
-import com.backend.domain.keyword.entity.Keyword;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import org.hibernate.validator.constraints.Length;
-
-import java.util.List;
 
 
 /**
@@ -32,7 +29,6 @@ public record MemberModifyRequestDto(
         Double latitude,
         Double longitude,
 
-        String introduction,    // 소개글
-        List<Keyword> keywords   // 키워드
+        String introduction    // 수정한 소개글
 ) {
 }

--- a/backend/src/main/java/com/backend/domain/member/dto/MemberRegisterRequestDto.java
+++ b/backend/src/main/java/com/backend/domain/member/dto/MemberRegisterRequestDto.java
@@ -33,8 +33,9 @@ public record MemberRegisterRequestDto(
 
         // 위도, 경도 추가
         Double latitude,
-        Double longitude
+        Double longitude,
 
+        String introduction // 소개글
 ) {
         /**
          * 카카오 사용자 정보로부터 회원가입 DTO 생성
@@ -49,7 +50,8 @@ public record MemberRegisterRequestDto(
                         0,             // 기본 키
 //                        new ArrayList<>(), // 빈 프로필 이미지 리스트
                         null,          // 위도
-                        null           // 경도
+                        null,           // 경도
+                        null
                 );
         }
 }

--- a/backend/src/main/java/com/backend/domain/member/dto/MemberResponseDto.java
+++ b/backend/src/main/java/com/backend/domain/member/dto/MemberResponseDto.java
@@ -2,8 +2,8 @@ package com.backend.domain.member.dto;
 
 import com.backend.domain.chatrequest.entity.ChatRequestStatus;
 import com.backend.domain.image.dto.ImageResponseDto;
-import com.backend.domain.keyword.entity.Keyword;
 import com.backend.domain.member.entity.Member;
+import com.backend.domain.userkeyword.dto.response.UserKeywordResponse;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,7 +22,7 @@ public record MemberResponseDto(
         ImageResponseDto profileImage,
         List<ImageResponseDto> images,
         String introduction,
-        List<Keyword> keywords,
+        List<UserKeywordResponse> keywords,
         Boolean liked,
         ChatRequestStatus chatRequestStatus,
         Boolean blockStatus,
@@ -30,7 +30,7 @@ public record MemberResponseDto(
         Double latitude,
         Double longitude
 ) {
-    public static MemberResponseDto from(Member member) {
+    public static MemberResponseDto from(Member member, List<UserKeywordResponse> keywords, boolean liked, ChatRequestStatus chatRequestStatus) {
         return new MemberResponseDto(
                 member.getId(),
                 member.getNickname(),
@@ -42,9 +42,9 @@ public record MemberResponseDto(
                     .map(ImageResponseDto::from)
                     .collect(Collectors.toList()),
                 member.getIntroduction(),
-                null,// 유저키워드 엔티티를 통해 보여짐 (기본값 null)
-                false, // 좋아요 는 Likes 엔티티를 통해 보여짐 (기본값 false)
-                null, // 채팅요청 여부는 실제 채팅 요청 여부에 따라 동적으로 결정 (기본값 null)
+                keywords,// 유저키워드 엔티티를 통해 동적으로 보여짐
+                liked, // 좋아요 는 Likes 엔티티를 통해 동적으로 보여짐
+                chatRequestStatus, // 채팅요청 여부는 실제 채팅 요청 여부에 따라 동적으로 결정
                 member.getBlockStatus(),
                 member.isDeleted(),
                 member.getLatitude(),

--- a/backend/src/main/java/com/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/backend/domain/member/service/MemberService.java
@@ -147,7 +147,7 @@ public class MemberService {
                         member.isChatAble(),           // 기존 chatAble 유지
                         requestDto.latitude(),          // 추가 정보: 위도
                         requestDto.longitude(),          // 추가 정보: 경도
-                        member.getIntroduction()
+                        requestDto.introduction()
                 );
                 redisGeoService.addLocation(member.getId(), member.getLatitude(), member.getLongitude());
                 return MemberInfoDto.from(member);

--- a/backend/src/main/java/com/backend/domain/userkeyword/dto/response/UserKeywordResponse.java
+++ b/backend/src/main/java/com/backend/domain/userkeyword/dto/response/UserKeywordResponse.java
@@ -13,14 +13,16 @@ import lombok.NoArgsConstructor;
 public class UserKeywordResponse {
 
     private Long id;
-
     private String name;
-
+    private Long categoryId;
+    private String categoryName;
 
     public static UserKeywordResponse from(Keyword keyword) {
         return UserKeywordResponse.builder()
                 .id(keyword.getId())
                 .name(keyword.getName())
+                .categoryId(keyword.getCategory() != null ? keyword.getCategory().getId() : null)
+                .categoryName(keyword.getCategory() != null ? keyword.getCategory().getCategoryName() : null)
                 .build();
     }
 }

--- a/backend/src/main/java/com/backend/domain/userkeyword/repository/UserKeywordRepository.java
+++ b/backend/src/main/java/com/backend/domain/userkeyword/repository/UserKeywordRepository.java
@@ -5,16 +5,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface UserKeywordRepository extends JpaRepository<UserKeyword, Long> {
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM UserKeyword uk WHERE uk.member.id = :memberId AND uk.keyword.category.id = :categoryId")
     void deleteByMemberIdAndKeywordCategoryId(@Param("memberId") Long memberId, @Param("categoryId") Long categoryId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM UserKeyword uk WHERE uk.member.id = :memberId")
     void deleteAllKeywordsByMemberId(@Param("memberId") Long memberId); // 프로필의 키워드를 수정할 때 사용, memberId에 해당하는 모든 키워드를 삭제함
 

--- a/backend/src/main/java/com/backend/domain/userkeyword/service/UserKeywordService.java
+++ b/backend/src/main/java/com/backend/domain/userkeyword/service/UserKeywordService.java
@@ -11,11 +11,13 @@ import com.backend.domain.userkeyword.repository.UserKeywordRepository;
 import com.backend.global.exception.GlobalErrorCode;
 import com.backend.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserKeywordService {
@@ -59,15 +61,13 @@ public class UserKeywordService {
                 () -> new GlobalException(GlobalErrorCode.MEMBER_NOT_FOUND)
         );
 
-        System.out.println("✅ updateUserKeywords 호출됨! 삭제 진행 시작");
-
         // 회원 정보 수정 시에는 기존에 선택한 키워드 전체 삭제 후 재등록
         userKeywordRepository.deleteAllKeywordsByMemberId(userId);
 
         // 영속성 컨텍스트에 있는 변경 사항을 DB에 즉시 반영
         userKeywordRepository.flush();
 
-        System.out.println("✅ 삭제 완료, 새로운 키워드 저장 시작");
+        log.info("✅ 기존 키워드 정보 삭제 완료, 새로운 키워드 저장 시작");
 
         // 새 키워드 저장
         List<Keyword> keywords = keywordRepository.findAllById(keywordIds);
@@ -80,8 +80,7 @@ public class UserKeywordService {
             userKeywordRepository.save(userKeyword);
         }
 
-        System.out.println("✅ 키워드 저장 완료");
-
+        log.info("✅ 새로운 키워드 정보 저장 완료");
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/backend/domain/userkeyword/service/UserKeywordService.java
+++ b/backend/src/main/java/com/backend/domain/userkeyword/service/UserKeywordService.java
@@ -59,10 +59,19 @@ public class UserKeywordService {
                 () -> new GlobalException(GlobalErrorCode.MEMBER_NOT_FOUND)
         );
 
+        System.out.println("✅ updateUserKeywords 호출됨! 삭제 진행 시작");
+
         // 회원 정보 수정 시에는 기존에 선택한 키워드 전체 삭제 후 재등록
         userKeywordRepository.deleteAllKeywordsByMemberId(userId);
 
+        // 영속성 컨텍스트에 있는 변경 사항을 DB에 즉시 반영
+        userKeywordRepository.flush();
+
+        System.out.println("✅ 삭제 완료, 새로운 키워드 저장 시작");
+
+        // 새 키워드 저장
         List<Keyword> keywords = keywordRepository.findAllById(keywordIds);
+
         for (Keyword keyword : keywords) {
             UserKeyword userKeyword = UserKeyword.builder()
                     .member(member)
@@ -70,6 +79,9 @@ public class UserKeywordService {
                     .build();
             userKeywordRepository.save(userKeyword);
         }
+
+        System.out.println("✅ 키워드 저장 완료");
+
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/backend/global/auth/kakao/service/KakaoAuthService.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/service/KakaoAuthService.java
@@ -63,8 +63,6 @@ public class KakaoAuthService {
 //    private String[] adminEmailDomains;
 
     private final AdminWhitelistProperties adminWhitelistProperties;
-    private final
-
 
     /**
      * 카카오 로그인 인가 요청 URL 반환

--- a/backend/src/main/java/com/backend/global/auth/kakao/service/KakaoAuthService.java
+++ b/backend/src/main/java/com/backend/global/auth/kakao/service/KakaoAuthService.java
@@ -11,6 +11,8 @@ import com.backend.global.auth.kakao.util.JwtUtil;
 import com.backend.global.auth.kakao.util.KakaoAuthUtil;
 import com.backend.global.auth.kakao.util.TokenProvider;
 import com.backend.global.config.AdminWhitelistProperties;
+import com.backend.global.exception.GlobalErrorCode;
+import com.backend.global.exception.GlobalException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.List;
@@ -60,6 +63,7 @@ public class KakaoAuthService {
 //    private String[] adminEmailDomains;
 
     private final AdminWhitelistProperties adminWhitelistProperties;
+    private final
 
 
     /**
@@ -73,29 +77,40 @@ public class KakaoAuthService {
      * 인가 코드를 통해 카카오로부터 토큰 발급받기
      */
 
-    public KakaoTokenResponseDto getTokenFromKakao(String code) {
-        return webClient.post()
-                .uri(kakaoAuthUtil.getKakaoLoginTokenUrl(code))
-                .retrieve()
-                .bodyToMono(KakaoTokenResponseDto.class)
-                .block();
-    }
-
 //    public KakaoTokenResponseDto getTokenFromKakao(String code) {
-//        // KakaoAuthUtil에서 토큰 발급 엔드포인트 URL만 반환하도록 수정
-//        String tokenUrl = kakaoAuthUtil.getKakaoTokenUrl(); // TOKEN_URL만 반환
-//
 //        return webClient.post()
-//                .uri(tokenUrl)
-//                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-//                .body(BodyInserters.fromFormData("grant_type", kakaoAuthUtil.getGrantType())
-//                        .with("client_id", kakaoAuthUtil.getClientId())
-//                        .with("redirect_uri", kakaoAuthUtil.getRedirectUri())
-//                        .with("code", code))
+//                .uri(kakaoAuthUtil.getKakaoLoginTokenUrl(code))
 //                .retrieve()
 //                .bodyToMono(KakaoTokenResponseDto.class)
 //                .block();
 //    }
+
+    public KakaoTokenResponseDto getTokenFromKakao(String code) {
+        // 인가 코드 로그 출력
+        log.info("[카카오 로그인] 전달받은 인가 코드: {}", code);
+
+        // KakaoAuthUtil에서 토큰 발급 엔드포인트 URL만 반환하도록 수정
+        String tokenUrl = kakaoAuthUtil.getKakaoTokenUrl(); // TOKEN_URL만 반환
+
+        KakaoTokenResponseDto kakaoTokenDto = webClient.post()
+                .uri(tokenUrl)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData("grant_type", kakaoAuthUtil.getGrantType())
+                        .with("client_id", kakaoAuthUtil.getClientId())
+                        .with("redirect_uri", kakaoAuthUtil.getRedirectUri())
+                        .with("code", code))
+                .retrieve()
+                .bodyToMono(KakaoTokenResponseDto.class)
+                .block();
+
+        // 토큰 응답 null 체크
+        if (kakaoTokenDto == null) {
+            log.error("❌ [카카오 로그인] KakaoTokenResponseDto가 null입니다. 토큰 발급 실패");
+            throw new GlobalException(GlobalErrorCode.KAKAO_LOGIN_FAILED, "카카오 토큰 발급 실패");
+        }
+
+        return kakaoTokenDto;
+    }
 
 
     /**

--- a/backend/src/main/java/com/backend/global/exception/GlobalErrorCode.java
+++ b/backend/src/main/java/com/backend/global/exception/GlobalErrorCode.java
@@ -16,6 +16,8 @@ public enum GlobalErrorCode {
 	// 카카오 로그인 에러
 	KAKAO_LOGIN_FAILED(HttpStatus.BAD_REQUEST, 400, "카카오 로그인 중 에러가 발생했습니다."),
 
+	// 회원가입 도중 에러
+	MEMBER_REGISTRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "회원가입 중 오류가 발생했습니다."),
 
 	// 이미지 도메인 세부 에러
 	IMAGE_COUNT_INVALID(HttpStatus.BAD_REQUEST, 400, "이미지는 1장 이상 5장 이하로 등록해야 합니다."),
@@ -35,7 +37,7 @@ public enum GlobalErrorCode {
 	CHATROOM_FORBIDDEN(HttpStatus.FORBIDDEN, 403, "채팅방에 접근할 수 없습니다."),
 
 	// 멤버 오류코드
-	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 유저를 찾을 수 없습니다."),
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "해당 멤버를 찾을 수 없습니다."),
 	DUPLICATE_MEMBER(HttpStatus.CONFLICT, 409, "이미 등록된 회원입니다."),
 
 	// 정리 필요
@@ -48,7 +50,6 @@ public enum GlobalErrorCode {
 	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, 401, "토큰이 만료되었습니다."),
 	UNSUPPORTED_JWT(HttpStatus.UNAUTHORIZED, 401, "지원하지 않는 JWT 입니다."),
 	REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, 404, "리프레시 토큰이 존재하지 않습니다."),
-	MEMBER_REGISTRATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "멤버를 찾을 수 없습니다."),
 	AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, 401, "인증된 사용자 정보를 가져올 수 없습니다."),
 	TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, 401, "Authorization 헤더가 존재하지 않거나 형식이 올바르지 않습니다."),
 


### PR DESCRIPTION
<!-- 제목 : convention: 기능명#issue 번호
  ex) [FEAT] : pull request template #17-->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra


## ✔️PR Type
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 주요 코드 리펙토링 (성능 최적화 등)
- [ ] 간단 코드 리펙토링 (주석, 코드 컨벤션, 오타 수정 등)
- [ ] 기타 (기타 사항 기입)


## ✔️PR Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 잘 적용 하였나요?
- [x] 테스트 코드 작성 / 단위 테스트 or 통합 테스트 진행 하셨나요?

## 🔎 작업 내용

1. 멤버 회원 정보 입력 시 소개글 정보 추가 및 엔티티에 저장

2. 회원가입 전반 흐름을 하나의 트랜잭션으로 통합 처리
- 회원가입 도중 예외 발생 시, 잘못된 회원가입 정보가 DB에 저장되지 않고 안전하게 롤백되도록 추가 구현

3. UserKeywordResponse에 category 필드 추가
- Lazy 로딩 오류 방지를 위해 DTO 변환 시 categoryId, categoryName 직접 추출

4. DTO 응답 구조 개선
- MemberInfoDto, MemberResponseDto에서 keywords를 List<UserKeywordResponse>로 통일 
- 전체 API 응답에서 사용자 키워드 정보를 명확히 확인 가능

5. 회원가입 흐름을 하나의 트랜잭션으로 통합 처리
- MemberService.registerMember() 하나로 전체 처리하도록 변경
- 컨트롤러 로직은 요청 전달과 응답 포맷 구성만 담당

6. 프로필 정보 수정할 때, 수정된 키워드 정보가 업데이트 되지 않는 오류 수정
- 키워드 전용 DTO인 UserKeywordSaveRequest 도입 및 적용
- 수정된 키워드가 업데이트되어 저장되지 않거나, 중복 저장되는 오류 해결
=> UserKeywordService.updateUserKeywords(...) 호출 시 기존 키워드 삭제 후 재등록하도록 처리 확인 및 반영
=> 테스트 결과, 키워드 정보 수정 시 기존 키워드는 정상적으로 삭제되고, 새로운 키워드로 반영됨

7. KakaoAuthService의 getTokenFromKakao 로직 리팩토링


resolves #73 
close #73

## 📈이미지 첨부
